### PR TITLE
Start playing at a specific time via url fragments

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -28,6 +28,7 @@
 	"plugins":{
 		"defaultConfig":{"enabled":true},
 		"list":{
+      "edu.harvard.dce.paella.SkipToTimeFromFragment": {"enabled":true},
 			"es.upv.paella.ImageControlPlugin":{"enabled":false},
 			"es.upv.paella.ShowEditorPlugin":{"enabled":true,"alwaysVisible":true},
 			"es.upv.paella.TrimmingPlayerPlugin":{"enabled":true},

--- a/plugins/edu.harvard.dce.paella.skipToTimeFromFragment/skipToTimeFromFragment.js
+++ b/plugins/edu.harvard.dce.paella.skipToTimeFromFragment/skipToTimeFromFragment.js
@@ -1,0 +1,43 @@
+// Enable this plugin in config.json to allow urls in the format of:
+// http://paella-video-url.com/<more stuff>#t=100
+//
+// to jump to the 100th second of a video when play starts. This emulates how
+// timecode linking works for youtube and other sites.
+//
+// Notes:
+//
+// * This will not work for live streams
+// * This should work fine if there are other fragments or no fragments at all
+// * See: http://en.wikipedia.org/wiki/Fragment_identifier#Examples
+//
+
+Class ("paella.plugins.SkipToTimeFromFragment", paella.EventDrivenPlugin, {
+  getName: function() {
+    return 'edu.harvard.dce.paella.SkipToTimeFromFragment';
+  },
+  hasNotSkippedYet: true,
+  getFragments: function() {
+    var fragments = [], hash;
+    var fragmentSeparatorLocation = window.location.href.indexOf('#') + 1;
+    var hashes = window.location.href.slice(fragmentSeparatorLocation).split('&');
+    for(var i = 0; i < hashes.length; i++) {
+      hash = hashes[i].split('=');
+      fragments[hash[0]] = hash[1];
+    }
+    return fragments;
+  },
+  getEvents:function() { return [paella.events.play]; },
+  checkEnabled:function(onSuccess) {
+    onSuccess(!paella.player.isLiveStream());
+  },
+  onEvent: function(eventType, params) {
+    var fragments = this.getFragments();
+    var desiredTime = parseFloat(fragments['t']);
+    if( desiredTime && this.hasNotSkippedYet ) {
+      this.hasNotSkippedYet = false;
+      setTimeout(function() { paella.events.trigger(paella.events.seekToTime,{time: desiredTime}); },500);
+    }
+  }
+});
+
+paella.plugins.skipToTimeFromFragment = new paella.plugins.SkipToTimeFromFragment();


### PR DESCRIPTION
This uses URL fragments similar to youtube and as described in the video
examples here:

http://en.wikipedia.org/wiki/Fragment_identifier#Examples

I feel like this is a sub-optimal way of building this feature and would love feedback from the paella core team about this feature and alternative approaches that don't rely on async javascript events. Thoughts?
