### PR TITLE
A simple layout calculator to make creating profiles easier

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
 		copy: {
 			paella: {
 				files: [
-					{expand: true, src: ['config/**', 'javascript/**', 'resources/bootstrap/**', 'resources/images/**', 'index.html', 'extended.html', 'paella-standalone.js'], dest: 'build/player/'},
+					{expand: true, src: ['config/**', 'javascript/**', 'resources/bootstrap/**', 'resources/images/**', 'index.html', 'extended.html', 'layout_calculator.html', 'paella-standalone.js'], dest: 'build/player/'},
 					{expand: true, cwd: 'src/flash_player/', src: "player.swf", dest: 'build/player/' },
 					{expand: true, cwd: 'repository_test/', src: '**', dest: 'build/'},
 					{expand: true, src:'plugins/*/resources/**', dest: 'build/player/resources/style/',

--- a/javascript/layoutCalculator.js
+++ b/javascript/layoutCalculator.js
@@ -1,0 +1,49 @@
+function updateVideoContainer(baseId, index, array) {
+  $('#' + baseId).css('width', $('#' + baseId + '_width').val() + 'px');
+  $('#' + baseId).css('height', $('#' + baseId + '_height').val() + 'px');
+  $('#' + baseId).css('top', $('#' + baseId + '_top').val() + 'px');
+  $('#' + baseId).css('left', $('#' + baseId + '_left').val() + 'px');
+};
+
+function fixAspectRatioFor(baseId, changedAttribute) {
+  if(changedAttribute == 'width') {
+    var newWidth = $('#' + baseId + '_width').val();
+    var widthRatio = $('#' + baseId + '_width').attr('step');
+    var heightRatio = $('#' + baseId + '_height').attr('step');
+    var newHeight = (newWidth / widthRatio) * heightRatio;
+    $('#' + baseId + '_height').val(newHeight);
+  } else {
+    var newHeight = $('#' + baseId + '_height').val();
+    var heightRatio = $('#' + baseId + '_height').attr('step');
+    var widthRatio = $('#' + baseId + '_width').attr('step');
+    var newWidth = (newHeight / heightRatio) * widthRatio;
+    $('#' + baseId + '_width').val(newWidth);
+  }
+  updateLayout();
+}
+
+function updateLayout(){
+  ['presenter', 'presentation'].forEach(updateVideoContainer);
+};
+
+$(function(){
+  updateLayout();
+
+  $('#presenter_top, #presenter_left, #presentation_top, #presentation_left').change(function(){
+    updateLayout();
+  });
+
+  $('#presenter_width, #presenter_height, #presentation_width, #presentation_height').change(function(el){
+    fixAspectRatioFor($(this).data('vid-type'), $(this).data('dimension-type'));
+  });
+
+  $('#aspect_ratio').change(function(){
+    var ratios = $('#aspect_ratio').val().split(':');
+    var widthRatio = ratios[0];
+    var heightRatio = ratios[1];
+
+    $('#presenter_width, #presentation_width').attr('step', widthRatio);
+    $('#presenter_height, #presentation_height').attr('step', heightRatio);
+
+  });
+});

--- a/layout_calculator.html
+++ b/layout_calculator.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8;">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Paella layout calculator</title>
+  <script type="text/javascript" src="javascript/jquery.js"></script>
+  <script type="text/javascript" src="javascript/layoutCalculator.js"></script>
+  <style type="text/css">
+    #controls{
+      border: 1px solid black;
+      margin-bottom: 2em;
+    }
+
+    #preview{
+      margin: 0px auto;
+      width: 1282px;
+      height: 722px;
+      border: 1px solid #ccc;
+      position: absolute;
+    }
+
+    #presenter, #presentation{
+      position: absolute;
+    }
+
+    #presenter{
+      background: #e4e4e4;
+    }
+
+    #presentation{
+      background: #cccccc;
+    }
+    .info {
+      font-size: smaller;
+      color: #ccc;
+    }
+  </style>
+
+  <body>
+    <div id="controls">
+      <strong>Presenter:</strong>
+      Width: <input id="presenter_width" data-vid-type="presenter" data-dimension-type="width" type="number" value="816" step="16" />
+      Height: <input id="presenter_height" data-vid-type="presenter" data-dimension-type="height" type="number" value="459" step="9" />
+      Top: <input id="presenter_top" data-vid-type="presenter" type="number" value="140" />
+      Left: <input id="presenter_left" data-vid-type="presenter" type="number" value="11" /><br/>
+      <strong>Presentation:</strong>
+      Width: <input  id="presentation_width" data-vid-type"presentation" data-dimension-type="width" type="number" value="416" step="16" />
+      Height: <input id="presentation_height" data-vid-type"presentation" data-dimension-type="height" type="number" value="234" step="9" />
+      Top: <input    id="presentation_top" data-vid-type"presentation" type="number" value="236" />
+      Left: <input   id="presentation_left" data-vid-type"presentation" type="number" value="850" /><br/>
+      <strong>Aspect Ratio</strong>
+      <select id="aspect_ratio">
+        <option>16:9</option>
+        <option>4:3</option>
+        <option>5:4</option>
+        <option>16:10</option>
+      </select> <span class="info"> Make a height or width modification to see the new aspect ratio take effect</span>
+    </div>
+
+    <div id="preview">
+      <div id="presenter">Presenter</div>
+      <div id="presentation">Presentation</div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This implements a simple visual editor to calculate positions, width, and height values for presentation and presenter videos. It includes the ability to "snap to" a few custom aspect ratios. This should make creating custom video layout profiles significantly easier. It operates separately from the paella player, relying only on jQuery.

![screenshot-2014-11-17t14 50 59](https://cloud.githubusercontent.com/assets/3966/5076527/75f46cd4-6e69-11e4-9b21-42cdbc5f3119.png)
