### PR TITLE
Fix html5 videonode setDefaultVolume in firefox

### DIFF
--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -737,7 +737,10 @@ Class ("paella.Html5Video", paella.VideoElementBase,{
 	},
 
 	setDefaultVolume:function(vol) {
-		if (vol==0) this.domElement.setAttribute("muted",true);
+		if (vol==0){
+			this.domElement.setAttribute("muted",true);
+		}
+		this.domElement.volume = vol;
 	},
 	
 	setVolume:function(volume) {


### PR DESCRIPTION
Firefox does not notice when the "muted" attribute is added to the video
tag, to properly mute an audio stream you must explicitly set the volume
through the javascript API.

I have a URL that demonstrates this bug, but basically just create a dual stream player with audio on both that uses the HTML5 player (so, webm or mp4 in the firefox 35 beta channel) and you'll see that both audio channels play. This fixes that bug and does not seem to impact other browsers (which makes sense, we're just using the default javascript API here).
