### PR TITLE
Issue 143, live stream mute button doesn't show unmuted: duration param

### DIFF
--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -297,10 +297,12 @@ Class ("paella.FlashVideo", paella.VideoElementBase,{
 	},
 	
 	processEvent:function(eventName,params) {
-		if (eventName!="loadedmetadata" && eventName!="pause" && params.duration!=0 && !this._isReady) {
-			this._isReady = true;
-			this._duration = params.duration;
-			this.callReadyEvent();
+		if (eventName!="loadedmetadata" && eventName!="pause" && !this._isReady) {
+                        if (paella.player.isLiveStream() || params.duration != 0) {
+			    this._isReady = true;
+			    this._duration = params.duration;
+			    this.callReadyEvent();
+                        }
 		}
 		if (eventName=="progress") {
 			try { this.flashVideo.setVolume(this._volume); }


### PR DESCRIPTION
Hi, This pull removes the duration requirement for live streaming for the paella.flashPlaer when it's a liveStream. Our Wowza doesn't send a duration in the data, and some other live servers also do not (http://support.brightcove.com/en/video-cloud/docs/media-module-deliver-live-streaming-video). 