### PR TITLE
Fixed reposiroty typo

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -89,7 +89,7 @@
 		}
 	},
     "standalone" : {
-        "reposiroty": "../repository/"
+        "repository": "../repository/"
     }
 }
 

--- a/doc/integrate_basic.md
+++ b/doc/integrate_basic.md
@@ -11,12 +11,12 @@ To add Paella Player to your portal, you need to do some easy steps:
   To configure paella you need to edit the ´config/config.json´ file. You can read how to configure paella
   in the [configuration page](configure.md)
 
-  In the `config/config.jsonfile` you need to modify the `standalone.reposiroty` parameter to point to your
+  In the `config/config.jsonfile` you need to modify the `standalone.repository` parameter to point to your
   repository folder. This value can be a relative URL or an absolute URL.
   
   ```js
     "standalone": {
-        "reposiroty": "../repository/"
+        "repository": "../repository/"
     }  
   ```
 

--- a/paella-standalone.js
+++ b/paella-standalone.js
@@ -98,7 +98,7 @@ paella.standalone.StandAloneVideoLoader = Class.create(paella.VideoLoader, {
 		}
 		else {
 			try {
-				return paella.player.config.standalone.reposiroty;
+				return paella.player.config.standalone.repository;
 			}
 			catch(e) {
 				return "";
@@ -429,7 +429,7 @@ paella.dataDelegates.StandaloneCaptionsDataDelegate = Class.create(paella.DataDe
 				if (selectedCaption){
 					var url = selectedCaption.url;
 					if (! /^[a-zA-Z]+:\/\//.test(url)) {
-						url = paella.player.config.standalone.reposiroty + "/" + params.id + "/" + url;
+						url = paella.player.config.standalone.repository + "/" + params.id + "/" + url;
 					}
 					
 					if (onSuccess) { onSuccess({error: false, url: url, format: selectedCaption.format}, true); }	        


### PR DESCRIPTION
There is a typo in the config parameter for the example repository, this fixes it.