### PR TITLE
Remove dependencies on #playerContainer id

### DIFF
--- a/src/06_ui_controls.js
+++ b/src/06_ui_controls.js
@@ -116,10 +116,10 @@ Class ("paella.PlaybackBar", paella.DomNode,{
 		var self = this;
 		var time = 0;
 		// CONTROLS_BAR POSITON
-		var p = $("#playerContainer_controls_playback_playbackBar");
+		var p = $(this.domElement);
 		var pos = p.offset();
 
-		var width = $("#playerContainer_controls_playback_playbackBar").width();
+		var width = p.width();
 		var left = (event.clientX-pos.left);
 		left = (left < 0) ? 0 : left;
 		var position = left * 100 / width; // GET % OF THE STREAM
@@ -312,9 +312,8 @@ Class ("paella.PlaybackBar", paella.DomNode,{
 
 		div.appendChild(div2);
 
-		var controlBar = document.getElementById('playerContainer_controls_playback');
-		controlBar.appendChild(div); //CHILD OF CONTROLS_BAR
-
+		//CHILD OF CONTROLS_BAR
+		$(this.domElement).parent().append(div);
 	},
 	
 	setupTimeOnly:function(time_str,top,width){
@@ -324,8 +323,8 @@ Class ("paella.PlaybackBar", paella.DomNode,{
 		div2.id = ("divTimeOverlay");
 		div2.innerHTML = time_str;
 
-		var controlBar = document.getElementById('playerContainer_controls_playback');
-		controlBar.appendChild(div2); //CHILD OF CONTROLS_BAR
+		//CHILD OF CONTROLS_BAR
+		$(this.domElement).parent().append(div2);
 	},
 
 	playbackFull:function() {

--- a/src/09_paella_player.js
+++ b/src/09_paella_player.js
@@ -255,8 +255,8 @@ Class ("paella.PaellaPlayer", paella.PlayerBase,{
 	},
 
 	unloadAll:function(message) {
-		$('#playerContainer')[0].innerHTML = "";
 		var loaderContainer = $('#paellaPlayer_loader')[0];
+		this.mainContainer.innerHTML = "";
 		paella.messageBox.showError(message);
 	},
 


### PR DESCRIPTION
paella.PlayerBase.initialize takes a playerId as the first argument.
This allows changing the id and in theory would allow multiple players
in one document. This id is used in a lot of places to construct unique
ids, but there are some places that expect a container with the id
`playerContainer`.

This tries to fix this. setupTimeOnly and setupTimeImageOverlay may
need further attention as they completely ignore the existing
paella.DomNode facilities.