### PR TITLE
Bind mousemove to the player container

### DIFF
--- a/src/06_ui_controls.js
+++ b/src/06_ui_controls.js
@@ -580,7 +580,7 @@ Class ("paella.ControlsContainer", paella.DomNode,{
 
 		paella.events.bind(paella.events.play,function(event) { thisClass.onPlayEvent(); });
 		paella.events.bind(paella.events.pause,function(event) { thisClass.onPauseEvent(); });
-		$(document).mousemove(function(event) {
+		$(paella.player.mainContainer).mousemove(function(event) {
 			paella.player.controls.restartTimerEvent();
 		});
 		paella.events.bind(paella.events.endVideo,function(event) { thisClass.onEndVideoEvent(); });


### PR DESCRIPTION
Controls should only be shown when the mouse is moved over the player
container, not the whole document. This is another change that enables
usage of paella embedded in page.

In typical usage mainContainer spans the whole page, so this doesn’t
change behavior there.
