### PR TITLE
Fixed editor not displaying saved changes on trimming.

### DIFF
--- a/plugins/es.upv.paella.TrimmingPlugins/trimming_editor.js
+++ b/plugins/es.upv.paella.TrimmingPlugins/trimming_editor.js
@@ -34,6 +34,9 @@ paella.plugins.TrimmingTrackPlugin = Class.create(paella.editor.MainTrackPlugin,
 		paella.player.videoContainer.enableTrimming();
 		paella.player.videoContainer.setTrimmingStart(this.trimmingTrack.s);
 		paella.player.videoContainer.setTrimmingEnd(this.trimmingTrack.e);
+
+		this.trimmingData.s = this.trimmingTrack.s;
+		this.trimmingData.e = this.trimmingTrack.e;
 		
 		paella.data.write('trimming',{id:paella.initDelegate.getId()},{start:this.trimmingTrack.s,end:this.trimmingTrack.e},function(data,status) {
 			onDone(status);


### PR DESCRIPTION
This bug on the trimming plugin editor was not obvious. It is visible when changing between editor/player views. Particularly:
1. Open the editor, do some changes, save and close. (Without reloading the page)
2. Open the editor again, do some changes (or not) and exit using the 'Discard changes' option. (Again without reloading)
3. Open the editor once more:
    The trimming bar will be shown as it was when we first opened it, no changes shown. However, when reloading the changes we saved will show correctly.