### PR TITLE
Fixed editor not discarding changes on Breaks plugin

### DIFF
--- a/plugins/es.upv.paella.breakPlugins/editor.js
+++ b/plugins/es.upv.paella.breakPlugins/editor.js
@@ -5,10 +5,13 @@ Class ("paella.plugins.BreaksEditorPlugin",paella.editor.MainTrackPlugin, {
 	checkEnabled:function(onSuccess) {
 		var This = this;
 		this.tracks = [];
+		this.tracksData = [];
 		paella.data.read('breaks',{id:paella.initDelegate.getId()},function(data,status) {
 			if (data && typeof(data)=='object' && data.breaks && data.breaks.length>0) {
 				This.tracks = data.breaks;
 			}
+			//Copy this.tracks on this.tracksData as backup.
+			This.tracksData = JSON.parse(JSON.stringify(This.tracks));
 			onSuccess(true);
 		});
 	},
@@ -126,7 +129,14 @@ Class ("paella.plugins.BreaksEditorPlugin",paella.editor.MainTrackPlugin, {
 			paella.plugins.breaksPlayerPlugin.breaks = data.breaks;
 			success(status);
 		});
+		//Update this.tracksData backup tracks
+		this.tracksData = JSON.parse(JSON.stringify(this.tracks));
 
+	},
+
+	onDiscard:function(success) {
+		//Override discarded changes using this.tracksData backup
+		this.tracks = JSON.parse(JSON.stringify(this.tracksData));
 	}
 });
 

--- a/plugins/es.upv.paella.breakPlugins/editor.js
+++ b/plugins/es.upv.paella.breakPlugins/editor.js
@@ -137,6 +137,7 @@ Class ("paella.plugins.BreaksEditorPlugin",paella.editor.MainTrackPlugin, {
 	onDiscard:function(success) {
 		//Override discarded changes using this.tracksData backup
 		this.tracks = JSON.parse(JSON.stringify(this.tracksData));
+		success(true);
 	}
 });
 


### PR DESCRIPTION
After leaving the editor using 'Discard changes' and entering  the editor again the discarded changes would still appear (although they wouldn't be saved if closing the browser)
I added a 'backup' for the breaks and implemented onDiscard to restore the last saved changes in the case the user decides to 'Discard'.