### PR TITLE
Fix bug when not resolution in BestFitVideoQualityStrategy

### DIFF
--- a/src/04_video_container.js
+++ b/src/04_video_container.js
@@ -296,7 +296,7 @@ Class ("paella.BestFitVideoQualityStrategy",paella.VideoQualityStrategy,{
 			var win_w = $(window).width();
 			var win_h = $(window).height();
 			var win_res = (win_w * win_h);
-			var selected_res = parseInt(selected.res.w) * parseInt(selected.res.h);
+			var selected_res = selected.res ? parseInt(selected.res.w) * parseInt(selected.res.h):0;
 			var selected_diff = Math.abs(win_res - selected_res);
 
 			for (var i=0; i<source.length; ++i) {


### PR DESCRIPTION
If the `paella.VideoLoader` doesn't provide the resolution the media,
the player stops because cannot read property 'w' of undefined.