### PR TITLE
paella/issues/241 start-end params num protection in setTrimming

### DIFF
--- a/src/04_video_container.js
+++ b/src/04_video_container.js
@@ -303,8 +303,8 @@ Class ("paella.VideoContainerBase", paella.DomNode,{
 
 				.then((d) => {
 					duration = d;
-					this._trimming.start = start;
-					this._trimming.end = end;
+					this._trimming.start = Math.floor(start);
+					this._trimming.end = Math.floor(end);
 					if (currentTime<this._trimming.start) {
 						this.setCurrentTime(this._trimming.start);
 					}


### PR DESCRIPTION
The setTrimming method seems like a good place to protect currentTime from accidentally being set to a string by the start-end params. (Sorry about that)