### PR TITLE
#249 viewModePlugin: Moved set cookie logic to paella.player.setProfile

### DIFF
--- a/plugins/es.upv.paella.viewModePlugin/viewmode.js
+++ b/plugins/es.upv.paella.viewModePlugin/viewmode.js
@@ -117,12 +117,6 @@ Class ("paella.plugins.ViewModePlugin",paella.ButtonPlugin,{
 		if (ButtonItem) {
 			ButtonItem.className = thisClass.getButtonItemClass(profile,true);
 			paella.player.setProfile(profile);
-			paella.player.getProfile(profile)
-				.then((profileData) => {
-					if (!profileData.isMonostream) {
-						base.cookies.set("lastProfile", profile);
-					}
-				});
 		}
 		paella.player.controls.hidePopUp(this.getName());
 	},

--- a/src/09_paella_player.js
+++ b/src/09_paella_player.js
@@ -137,7 +137,15 @@ Class ("paella.PaellaPlayer", paella.PlayerBase,{
 
 
 	setProfile:function(profileName,animate) {
-		this.videoContainer.setProfile(profileName,animate);
+		  this.videoContainer.setProfile(profileName,animate)
+          .then((profileName) => {
+              return paella.player.getProfile(profileName);
+          })
+          .then((profileData) => {
+              if (!profileData.isMonostream) {
+                  base.cookies.set("lastProfile", profile);
+              }
+          });
 	},
 
 	getProfile:function(profileName) {


### PR DESCRIPTION
This should assure that the cookie is set whenever you call the setProfile function, regardless of where you call it.