### PR TITLE
#257 Bracks don't end at the correct time with trimmed video

### DIFF
--- a/plugins/es.upv.paella.breakPlugins/player.js
+++ b/plugins/es.upv.paella.breakPlugins/player.js
@@ -74,7 +74,7 @@ Class ("paella.plugins.BreaksPlayerPlugin",paella.EventDrivenPlugin,{
 	},
 
 	avoidBreak:function(br){
-		var newTime = br.e + (this.config.neverShow?0.01:0);
+		var newTime = br.e + (this.config.neverShow?0.01:0) - paella.player.videoContainer.trimStart();
 		paella.player.videoContainer.seekToTime(newTime);
 	}
 });


### PR DESCRIPTION
Fixes #257 .
 
Changes proposed in this pull request:
- Check the videoContainer `trimStart` when `seekToTime` in the `breakPlugin`.


