### PR TITLE
Play/Pause button in smartphone livestream videos

### DIFF
--- a/plugins/es.upv.paella.playPauseButtonPlugin/playbutton.js
+++ b/plugins/es.upv.paella.playPauseButtonPlugin/playbutton.js
@@ -10,7 +10,8 @@ Class ("paella.plugins.PlayPauseButtonPlugin",paella.ButtonPlugin, {
 	getIndex:function() {return 110;},
 
 	checkEnabled:function(onSuccess) {
-		onSuccess(!paella.player.isLiveStream());
+		onSuccess(!paella.player.isLiveStream() || base.userAgent.system.Android 
+			|| base.userAgent.system.iOS);
 	},
 
 	setup:function() {

--- a/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
+++ b/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
@@ -9,7 +9,8 @@ Class ("paella.plugins.PlayButtonOnScreen",paella.EventDrivenPlugin,{
 	firstPlay:false,
 
 	checkEnabled:function(onSuccess) {
-		onSuccess(!paella.player.isLiveStream());
+		onSuccess(!paella.player.isLiveStream() || base.userAgent.system.Android 
+			|| base.userAgent.system.iOS);
 	},
 
 	getIndex:function() {


### PR DESCRIPTION
Fixes #272.

Changes proposed in this pull request:
- Play/pause button is always showed in mobile platforms.

