### PR TITLE
Fixed tab crash if break is longer than video

### DIFF
--- a/plugins/es.upv.paella.breakPlugins/player.js
+++ b/plugins/es.upv.paella.breakPlugins/player.js
@@ -1,60 +1,78 @@
 paella.addPlugin(() => {
 	return class BreaksPlayerPlugin extends paella.EventDrivenPlugin {
-		get breaks() { return this._breaks || [] }
-		set breaks(b) { this._breaks = b; }
-		get lastEvent() { return this._lastEvent || 0; }
-		set lastEvent(e) { this._lastEvent = e; }
-		get visibleBreaks() { return this._visibleBreaks || []; }
-		set visibleBreaks(v) { this._visibleBreaks = v; }
+		get breaks() {
+			return this._breaks || []
+		}
+		set breaks(b) {
+			this._breaks = b;
+		}
+		get lastEvent() {
+			return this._lastEvent || 0;
+		}
+		set lastEvent(e) {
+			this._lastEvent = e;
+		}
+		get visibleBreaks() {
+			return this._visibleBreaks || [];
+		}
+		set visibleBreaks(v) {
+			this._visibleBreaks = v;
+		}
 
-		getName() { return "es.upv.paella.breaksPlayerPlugin"; }
+		getName() {
+			return "es.upv.paella.breaksPlayerPlugin";
+		}
 		checkEnabled(onSuccess) {
 			var This = this;
-			paella.data.read('breaks',{id:paella.initDelegate.getId()},function(data,status) {
-				if (data && typeof(data)=='object' && data.breaks && data.breaks.length>0) {
+			paella.data.read('breaks', {
+				id: paella.initDelegate.getId()
+			}, function (data, status) {
+				if (data && typeof (data) == 'object' && data.breaks && data.breaks.length > 0) {
 					This.breaks = data.breaks;
 				}
 				onSuccess(true);
 			});
 		}
 
-		getEvents() { return [paella.events.timeUpdate]; }
+		getEvents() {
+			return [paella.events.timeUpdate];
+		}
 
-		onEvent(eventType,params) {
+		onEvent(eventType, params) {
 			var thisClass = this;
 
 			params.videoContainer.currentTime(true)
-				.then(function(currentTime) {
+				.then(function (currentTime) {
 					thisClass.checkBreaks(currentTime);
 				});
 		}
 
 		checkBreaks(currentTime) {
 			var a;
-			for (var i=0; i<this.breaks.length; ++i) {
+			for (var i = 0; i < this.breaks.length; ++i) {
 				a = this.breaks[i];
 
-				if (a.s<currentTime && a.e>currentTime) {
-								if(this.areBreaksClickable())
-									this.avoidBreak(a);
-								else
-									this.showBreaks(a);
-				} else if (a.s.toFixed(0) == currentTime.toFixed(0)){
+				if (a.s < currentTime && a.e > currentTime) {
+					if (this.areBreaksClickable())
+						this.avoidBreak(a);
+					else
+						this.showBreaks(a);
+				} else if (a.s.toFixed(0) == currentTime.toFixed(0)) {
 					this.avoidBreak(a);
 				}
 			}
-			if(!this.areBreaksClickable()) {
+			if (!this.areBreaksClickable()) {
 				for (var key in this.visibleBreaks) {
-					if (typeof(a)=='object') {
+					if (typeof (a) == 'object') {
 						a = this.visibleBreaks[key];
-						if (a && (a.s>=currentTime || a.e<=currentTime)) {
+						if (a && (a.s >= currentTime || a.e <= currentTime)) {
 							this.removeBreak(a);
 						}
 					}
 				}
 			}
 		}
-		
+
 		areBreaksClickable() {
 			//Returns true if the config value is set and if we are not on the editor.
 			return this.config.neverShow && !(paella.editor.instance && paella.editor.instance.isLoaded);
@@ -62,9 +80,14 @@ paella.addPlugin(() => {
 
 		showBreaks(br) {
 			if (!this.visibleBreaks[br.s]) {
-				var rect = {left:100,top:350,width:1080,height:40};
+				var rect = {
+					left: 100,
+					top: 350,
+					width: 1080,
+					height: 40
+				};
 				let name = br.name || paella.dictionary.translate("Break")
-				br.elem = paella.player.videoContainer.overlayContainer.addText(name,rect);
+				br.elem = paella.player.videoContainer.overlayContainer.addText(name, rect);
 				br.elem.className = 'textBreak';
 				this.visibleBreaks[br.s] = br;
 			}
@@ -79,8 +102,31 @@ paella.addPlugin(() => {
 		}
 
 		avoidBreak(br) {
-			var newTime = br.e + (this.config.neverShow?0.01:0) - paella.player.videoContainer.trimStart();
-			paella.player.videoContainer.seekToTime(newTime);
+			var newTime;
+			if (paella.player.videoContainer.trimEnabled()) {
+				paella.player.videoContainer.trimming()
+					.then((trimming) => {
+						if (br.e >= trimming.end) {
+							newTime = 0;
+							paella.player.videoContainer.pause();
+						} else {
+							newTime = br.e + (this.config.neverShow ? 0.01 : 0) - trimming.start;
+						}
+						paella.player.videoContainer.seekToTime(newTime);
+
+					});
+			} else {
+				paella.player.videoContainer.duration(true)
+					.then((duration) => {
+						if (br.e >= duration) {
+							newTime = 0;
+							paella.player.videoContainer.pause();
+						} else {
+							newTime = br.e + (this.config.neverShow ? 0.01 : 0);
+						}
+						paella.player.videoContainer.seekToTime(newTime);
+					});
+			}
 		}
 	}
 });


### PR DESCRIPTION
Bug: If the end of a video break is longer than video's duration the browser/tab crashes.

Changes proposed in this pull request:
- If this occurs, the video is paused and sought to the start as if it have ended normally.
