### PR TITLE
Fix for Master video (first in stream array) as  mainAudioPlayer during setAudioLanguage

### DIFF
--- a/src/04_video_container.js
+++ b/src/04_video_container.js
@@ -1157,7 +1157,7 @@ Class ("paella.LimitedSizeProfileFrameStrategy", paella.ProfileFrameStrategy, {
 						let promises = [];
 						
 						players.forEach((player) => {
-							if (player.stream.language==lang) {
+							if (!audioSet && (player.stream.language==lang)) {
 								audioSet = true;
 								this._audioPlayer = player;
 							}
@@ -1583,3 +1583,4 @@ Class ("paella.LimitedSizeProfileFrameStrategy", paella.ProfileFrameStrategy, {
 	paella.VideoContainer = VideoContainer;
 
 })();
+


### PR DESCRIPTION
Fixes #  (a problem with choosing master as the mainAudioPlayer during  setAudioLanguage() )

Changes proposed in this pull request:
- The setAudioLanguage() is currently choosing the last stream in the set of players to be the "this._audioPlayer" which is usually the last slave. The "master" video is usually the first in the array but the loop choose the last to be the audioPlayer.
- This pull adds the (!audioSet) to prevent selecting another audioPlayer after the first (the master) is found. 
- The current code sets "audioSet" to false right before the audioPlayer selection loop, so the omission of the audioSet check appears to be an existing bug.

