### PR TITLE
Feature request #291: Optional pause for onresize timer in PluginManager

### DIFF
--- a/src/05_plugin_base.js
+++ b/src/05_plugin_base.js
@@ -22,7 +22,7 @@
 		pluginList: [],
 		eventDrivenPlugins: [],
 		enabledPlugins: [],
-	
+		doResize: true,
 	
 	//	checkPluginVisibility
 	
@@ -51,7 +51,7 @@
 			});
 			
 			var timer = new base.Timer(function() {
-				if (paella.player && paella.player.controls) paella.player.controls.onresize();
+				if (paella.player && paella.player.controls && This.doResize) paella.player.controls.onresize();
 			}, 1000);
 			timer.repeat = true;
 		},


### PR DESCRIPTION
Feature for feature request #291:Optionally pause onresize timer in PluginManager.

Changes proposed in this pull request:
- Adds new PluginManager  attribute "doResize" that defaults to true
- PluginManager checks "doResize" attribute before calling onresize() in its timer.
- This attribute gives custom plugins the ability to call "paella.pluginManager.doResize = false;" before an activity that conflicts with onresize() activity. Then, "paella.pluginManager.doResize = true;" after the conflict has passed.
