### PR TITLE
Qualities canvas overlay alignment and unique id fix

### DIFF
--- a/plugins/es.upv.paella.videoZoom/video_zoom.less
+++ b/plugins/es.upv.paella.videoZoom/video_zoom.less
@@ -47,6 +47,12 @@
     justify-content: center;
 }
 
+/* The canvas "freeze frame" to overlay video element, instead of flex side aligned */
+.freezeFrame {
+    align-self:center;
+    position: absolute;
+}
+
 .videoZoomButton {
     z-index: 1;
     margin-left: 2px;

--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -1005,7 +1005,7 @@ Class ("paella.Html5Video", paella.VideoElementBase,{
 
 	unFreeze:function(){
 		return this._deferredAction(() => {
-			var c = document.getElementById(this.video.className + "canvas");
+			var c = document.getElementById(this.video.id + "canvas");
 			if (c) {
 				$(c).remove();
 			}
@@ -1016,7 +1016,8 @@ Class ("paella.Html5Video", paella.VideoElementBase,{
 		var This = this;
 		return this._deferredAction(function() {
 			var canvas = document.createElement("canvas");
-			canvas.id = This.video.className + "canvas";
+			canvas.id = This.video.id + "canvas";
+			canvas.className = "freezeFrame";
 			canvas.width = This.video.videoWidth;
 			canvas.height = This.video.videoHeight;
 			canvas.style.cssText = This.video.style.cssText;


### PR DESCRIPTION
Fixes #294

Changes proposed in this pull request:
- add class name "freezeFrame" to the HTML5 freeze() canvas video overlay to  give it style.
- add style to ".freezeFrame" to prevent it being side aligned with the video that it needs to overlay during freeze() event in the Qualities toggle.
- correct the canvas ID to be a unique id by integrating with the video element ID

Note: adding freezeFrame style into the zoom  plugin css since this is where videoWrapper gets its flex CSS that affects the canvas (freezeFrame) overlay.
