### PR TITLE
Captions with two lines get cut from below when the controls bar hides

### DIFF
--- a/plugins/es.upv.paella.captionsPlugin/overlayCaptionsPlugin.js
+++ b/plugins/es.upv.paella.captionsPlugin/overlayCaptionsPlugin.js
@@ -102,9 +102,11 @@ Class ("paella.plugins.CaptionsOnScreen",paella.EventDrivenPlugin,{
 					if(caption){
 						$(this.container).show();
 						this.innerContainer.innerHTML = caption.content;
+						this.moveCaptionsOverlay("auto");
 					}
 					else { 
 						this.innerContainer.innerHTML = ""; 
+						this.hideContent();
 					}
 				});
 		}
@@ -118,16 +120,21 @@ Class ("paella.plugins.CaptionsOnScreen",paella.EventDrivenPlugin,{
  
 	moveCaptionsOverlay:function(pos){
 		var thisClass = this;
+		var marginbottom = 10;
 
 		if(thisClass.controlsPlayback==null) thisClass.controlsPlayback = $('#playerContainer_controls_playback');
 		
+		if(pos=="auto" || pos==undefined) {
+			pos = paella.player.controls.isHidden() ? "down" : "top";
+		}
 		if(pos=="down"){
-			var t = thisClass.controlsPlayback.offset().top;
-			thisClass.innerContainer.style.bottom = (-thisClass.container.offsetHeight+50)+"px";
+			var t = thisClass.container.offsetHeight;
+			t -= thisClass.innerContainer.offsetHeight + marginbottom;
+			thisClass.innerContainer.style.bottom = (0 - t) + "px";
 		}
 		if(pos=="top") {
 			var t2 = thisClass.controlsPlayback.offset().top;
-			t2 -= thisClass.innerContainer.offsetHeight+10;
+			t2 -= thisClass.innerContainer.offsetHeight + marginbottom;
 			thisClass.innerContainer.style.bottom = (0-t2)+"px";
 		}
 	},


### PR DESCRIPTION
Steps to reproduce:

1.- Go to Paella Player captions video example.
2.- Inspect it and change the resolution to one below 600 px width.
3.- Reproduce it and wait until the controls bar hides.

Actual Behavior:

Most of the captions appear in two lines and the second line appears cut from below.

Expected Behavior:

It should show the second line complete. With only one line it does not occur.

Fixes #297 
