### PR TITLE
issue294 videoWrapper vertical load

### DIFF
--- a/plugins/es.upv.paella.videoZoom/video_zoom.less
+++ b/plugins/es.upv.paella.videoZoom/video_zoom.less
@@ -42,11 +42,6 @@
     border: 1px solid #0e0e0e;
 }
 
-.videoWrapper {
-    display: flex;
-    justify-content: center;
-}
-
 .videoZoomButton {
     z-index: 1;
     margin-left: 2px;
@@ -59,7 +54,8 @@
     box-shadow: 2px 2px 5px 0px black;
     width: 30px;
     height: 30px;
-    flex-direction: row-reverse;
+    position: relative;
+    left: 40%;
 }
 
 .videoZoomButton.zoomOut {


### PR DESCRIPTION
Fixes #294  wonky video load on vertical browser when zoomVideo is disabled.

Changes proposed in this pull request:
- remove global styling of videoWrapper class by zoomVideo plugin
- preserve videoZoomButton central align styling
- prevents wonky offset video load on vertical browsers when zoomVideo is disabled

