### PR TITLE
issue294 videoWrapper vertical load

### DIFF
--- a/plugins/es.upv.paella.videoZoom/video_zoom.less
+++ b/plugins/es.upv.paella.videoZoom/video_zoom.less
@@ -42,11 +42,6 @@
     border: 1px solid #0e0e0e;
 }
 
-.videoWrapper {
-    display: flex;
-    justify-content: center;
-}
-
 /* The canvas "freeze frame" to overlay video element, instead of flex side aligned */
 .freezeFrame {
     align-self:center;
@@ -65,7 +60,8 @@
     box-shadow: 2px 2px 5px 0px black;
     width: 30px;
     height: 30px;
-    flex-direction: row-reverse;
+    position: relative;
+    left: 40%;
 }
 
 .videoZoomButton.zoomOut {
@@ -119,3 +115,4 @@
 
 .videoZoomToolbarItem.zoomOut {
 }
+

--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -104,7 +104,7 @@ Class ("paella.VideoRect", paella.DomNode, {
 		let zoomSettings = paella.player.config.player.videoZoom || {};
 		let zoomEnabled = (zoomSettings.enabled!==undefined ? zoomSettings.enabled : true) && this.allowZoom();
 
-		this.parent(domType,id,zoomEnabled ? {width:this._zoom + '%',height:"100%",position:'absolute'} : { width:"100%" });
+		this.parent(domType,id,zoomEnabled ? {width:this._zoom + '%',height:"100%",position:'absolute'} : { width:"100%", height:"100%" });
 
 		let eventCapture = document.createElement('div');
 		setTimeout(() => this.domElement.parentElement.appendChild(eventCapture), 10);


### PR DESCRIPTION
Fixes #294 wonky video load on vertical browser when zoomVideo is disabled.

Changes proposed in this pull request:

-     remove global styling of videoWrapper class by zoomVideo plugin
-     preserve videoZoomButton central align styling
-     prevents wonky offset video load on vertical browsers when zoomVideo is disabled
-     fixes side affect of the above fixes, which was missing height for rtmp div around swf object

The second commit on this pull to avoid the CI uglify error is not really part of this pull. There is something wrong with the gulp-uglify lately. Adding debug causes the uglify error to not show at all.

