### PR TITLE
Switch to gulp-uglify-es 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ const	gulp = require('gulp'),
 		merge = require('gulp-merge-json'),
 		fs = require('fs'),
 		minify = require('gulp-minify'),
-		uglify = require('gulp-uglify'),
+		uglify = require('gulp-uglify-es').default,
 		flatten = require('gulp-flatten'),
 		path = require('path'),
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "traceur": "0.0.111",
     "gulp-traceur": "^0.17.2",
-    "gulp-uglify": "^2.0.0",
+    "gulp-uglify-es": "^1.0.0",
     "gulp-minify": "^1.0.0",
     "run-sequence": "^1.2.2",
     "gulp-nightwatch": "^0.3.2",


### PR DESCRIPTION
Fixes #320 .
 

Changes proposed in this pull request:
- Use gulp-uglify-es 1.0.0 instead of gulp-uglify 2.0.0

The reason is that gulp-uglify (2.0.0 and also 3.0.0) does not support ES2015: According to https://github.com/terinjokes/gulp-uglify, it uses UglifyJS3 which according to https://github.com/mishoo/UglifyJS2 (don't mind the number "2" here, the page is for version 3) does only support ES5 (not ES6/ES2015).

So if you want to uglify the ES2015 version of the Paella player, gulp-uglify is not an option.

The resulting file sizes are comparable.
