### PR TITLE
Track4k auto zoom fixes

### DIFF
--- a/plugins/es.upv.paella.track4kPlugin/main.js
+++ b/plugins/es.upv.paella.track4kPlugin/main.js
@@ -7,7 +7,7 @@ paella.addDataDelegate("cameraTrack",() => {
                 videoUrl += 'trackhd.json';
                 paella.utils.ajax.get({ url:videoUrl },
                     (data) => {
-                        if (typeof(data)=="string") {
+                        if (typeof(data)==="string") {
                             try {
                                 data = JSON.parse(data);
                             }
@@ -15,8 +15,8 @@ paella.addDataDelegate("cameraTrack",() => {
                         }
                         data.positions.sort((a,b) => {
                             return a.time-b.time;
-                        })
-                        onSuccess(data)
+                        });
+                        onSuccess(data);
                     },
                     () => onSuccess(null) );
             }
@@ -24,10 +24,10 @@ paella.addDataDelegate("cameraTrack",() => {
                 onSuccess(null);
             }
         }
-    
+
         write(context,params,value,onSuccess) {
         }
-    
+
         remove(context,params,onSuccess) {
         }
     };
@@ -36,16 +36,20 @@ paella.addDataDelegate("cameraTrack",() => {
 (() => {
     // Used to connect the toolbar button with the track4k plugin
     let g_track4kPlugin = null;
-    
-    
+
+
     function updatePosition(positionData,nextFrameData) {
         let twinTime = nextFrameData ? (nextFrameData.time - positionData.time) * 1000 : 100;
         if (twinTime>2000) twinTime = 2000;
-        let zoom = this._videoData.originalWidth / this._videoData.width;
-        let rect = (positionData && positionData.rect) || [0, 0];
-        let left = rect[0] / this._videoData.originalWidth;
-        let top = (rect[1] + this._videoData.originalHeight / 2) / this._videoData.originalHeight; 
-        paella.player.videoContainer.masterVideo().setZoom(zoom  * 100,left * zoom * 100,(top * zoom - 1) * 100, twinTime);
+        let rect = (positionData && positionData.rect) || [0, 0, 0, 0];
+        let offset_x = Math.abs(rect[0]);
+        let offset_y = Math.abs(rect[1]);
+        let view_width = rect[2];
+        let view_height = rect[3];
+        let zoom = this._videoData.originalWidth / view_width;
+        let left = offset_x / this._videoData.originalWidth;
+        let top = offset_y / this._videoData.originalHeight;
+        paella.player.videoContainer.masterVideo().setZoom(zoom  * 100,left * zoom * 100, top * zoom * 100, twinTime);
     }
 
     function nextFrame(time) {
@@ -55,7 +59,7 @@ paella.addDataDelegate("cameraTrack",() => {
             if (data.time>=time) {
                 index = i;
             }
-            return index!=-1;
+            return index!==-1;
         });
         // Index contains the current frame index
         if (this._trackData.length>index+1) {
@@ -69,12 +73,16 @@ paella.addDataDelegate("cameraTrack",() => {
     function prevFrame(time) {
         let frame = this._trackData[0];
         time = Math.round(time);
-        this._trackData.some((data,i) => {
-            if (data.time==time) {
+        this._trackData.some((data, i, frames) => {
+          if (frames[i+1]) {
+            if (data.time <= time && frames[i+1].time > time) {
                 return true;
             }
-            frame = data;
-            return false;
+          } else {
+            return true;
+          }
+          frame = data;
+          return false;
         });
         return frame;
     }
@@ -82,15 +90,21 @@ paella.addDataDelegate("cameraTrack",() => {
     function curFrame(time) {
         let frameRect = null;
         time = Math.round(time);
-        this._trackData.some((data,index) => {
-            if (data.time==time) {
+        this._trackData.some((data,i, frames) => {
+          if (data.time <= time) {
+            if (frames[i+1]) {
+              if (frames[i+1].time > time) {
                 frameRect = data;
+              }
+            } else {
+              frameRect = data;
             }
-            return frameRect!=null;
+          }
+          return frameRect!==null;
         });
         return frameRect;
     }
-    
+
 
     paella.addPlugin(function() {
         return class Track4KPlugin extends paella.EventDrivenPlugin {
@@ -99,7 +113,7 @@ paella.addDataDelegate("cameraTrack",() => {
 
                 g_track4kPlugin = this;
 
-                this._videoData = {}
+                this._videoData = {};
                 this._trackData = [];
 
                 this._enabled = true;
@@ -127,33 +141,38 @@ paella.addDataDelegate("cameraTrack",() => {
             set enabled(e) {
                 this._enabled = e;
                 if (this._enabled) {
-                    updatePosition.apply(this,[this._lastPosition]);
+                  let thisClass = this;
+                  paella.player.videoContainer.currentTime().then(function(time) {
+                    thisClass.updateZoom(time);
+                  });
                 }
             }
-    
+
             getName() { return "es.upv.paella.track4kPlugin"; }
             getEvents() {
-                return [ paella.events.timeupdate, paella.events.play, paella.events.seekToTime ]
+                return [ paella.events.timeupdate, paella.events.play, paella.events.seekToTime ];
             }
             onEvent(eventType,data) {
                 if (!this._trackData.length) return;
-                if (eventType==paella.events.play) {
+                if (eventType===paella.events.play) {
                 }
-                else if (eventType==paella.events.timeupdate) {
-                    this.updateZoom(data.currentTime);    
+                else if (eventType===paella.events.timeupdate) {
+                    this.updateZoom(data.currentTime);
                 }
-                else if (eventType==paella.events.seekToTime) {
+                else if (eventType===paella.events.seekToTime) {
                     this.seekTo(data.newPosition);
                 }
             }
-    
+
             updateZoom(currentTime) {
+              if (this._enabled) {
                 let data = curFrame.apply(this,[currentTime]);
                 let nextFrameData = nextFrame.apply(this,[currentTime]);
-                if (data && this._lastPosition!=data && this._enabled) {
+                if (data && this._lastPosition!==data) {
                     this._lastPosition = data;
                     updatePosition.apply(this,[data,nextFrameData]);
                 }
+              }
             }
 
             seekTo(time) {
@@ -164,11 +183,11 @@ paella.addDataDelegate("cameraTrack",() => {
                 }
             }
 
-        }
+        };
     });
-    
+
     paella.addPlugin(function() {
-        
+
         return class VideoZoomTrack4KPlugin extends paella.ButtonPlugin {
             getAlignment() { return 'right'; }
             getSubclass() { return "videoZoomToolbar"; }
@@ -181,7 +200,7 @@ paella.addDataDelegate("cameraTrack",() => {
             getName() { return "es.upv.paella.videoZoomTrack4kPlugin"; }
             getDefaultToolTip() { return base.dictionary.translate("Set video zoom"); }
             getButtonType() { return paella.ButtonPlugin.type.popUpButton; }
-    
+
             checkEnabled(onSuccess) {
                 paella.player.videoContainer.videoPlayers()
                     .then((players) => {
@@ -195,21 +214,23 @@ paella.addDataDelegate("cameraTrack",() => {
                                   this.targetPlayer.allowZoom());
                     });
             }
-            
+
             buildContent(domElement) {
-                let updateButtonIcon = () => {
+                this.changeIconClass("icon-mini-zoom-in");
+                g_track4kPlugin.updateTrackingStatus = () => {
                     if (g_track4kPlugin.enabled) {
-                        this.changeIconClass("icon-mini-videocamera");
+                      $('.zoom-auto').addClass("autoTrackingActivated");
+                      $('.icon-mini-zoom-in').addClass("autoTrackingActivated");
+                    } else {
+                      $('.zoom-auto').removeClass("autoTrackingActivated");
+                      $('.icon-mini-zoom-in').removeClass("autoTrackingActivated");
                     }
-                    else {
-                        this.changeIconClass("icon-mini-zoom-in");
-                    }
-                }
+                };
                 paella.events.bind(paella.events.videoZoomChanged, (evt,target) => {
-                    updateButtonIcon();
+                    g_track4kPlugin.updateTrackingStatus;
                 });
-                updateButtonIcon();
-        
+                g_track4kPlugin.updateTrackingStatus;
+
                 function getZoomButton(className,onClick,content) {
                     let btn = document.createElement('div');
                     btn.className = `videoZoomToolbarItem ${ className }`;
@@ -228,6 +249,9 @@ paella.addDataDelegate("cameraTrack",() => {
                 domElement.appendChild(getZoomButton('zoom-out',(evt) => {
                     this.zoomOut();
                 }));
+                domElement.appendChild(getZoomButton('picture',(evt) => {
+                    this.resetZoom();
+                }));
                 domElement.appendChild(getZoomButton('zoom-auto',(evt) => {
                     this.zoomAuto();
                     paella.player.controls.hidePopUp(this.getName());
@@ -235,19 +259,26 @@ paella.addDataDelegate("cameraTrack",() => {
             }
 
             zoomIn() {
-                g_track4kPlugin.enabled = false;
-                this.targetPlayer.zoomIn();
+              g_track4kPlugin.enabled = false;
+              this.targetPlayer.zoomIn();
             }
 
             zoomOut() {
-                g_track4kPlugin.enabled = false;
-                this.targetPlayer.zoomOut();
+              g_track4kPlugin.enabled = false;
+              this.targetPlayer.zoomOut();
+            }
+
+            resetZoom() {
+              g_track4kPlugin.enabled = false;
+              this.targetPlayer.setZoom(100,0,0,500);
+              g_track4kPlugin.updateTrackingStatus();
             }
 
             zoomAuto() {
-                g_track4kPlugin.enabled = true;
+              g_track4kPlugin.enabled = ! g_track4kPlugin.enabled;
+              g_track4kPlugin.updateTrackingStatus();
             }
-        }
+        };
     });
 })();
 

--- a/plugins/es.upv.paella.track4kPlugin/style.css
+++ b/plugins/es.upv.paella.track4kPlugin/style.css
@@ -14,3 +14,7 @@
     font-size: 29px;
     margin-left: -6px;
 }
+
+.autoTrackingActivated {
+    color: red !important;
+}


### PR DESCRIPTION
Fixed problems in processing trackhd.json file. 
Enabled auto-tracking to be turned on/off, while keeping the current view.
Added button to reset view.
Used red font color to mark if autotracking is on/off. Removed confusing camera icon, that replaced the zoom menu icon. I had a hard time to find out that the menu was not broken, when enabling auto-tracking.
Fixed selection of current zoom-frame after seeking, as now the last active frame is selected.

