### PR TITLE
Return play and pause promise

### DIFF
--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -947,13 +947,13 @@ Class ("paella.Html5Video", paella.VideoElementBase,{
 
 	play:function() {
         return this._deferredAction(() => {
-            this.video.play();
+            return this.video.play();
         });
 	},
 
 	pause:function() {
         return this._deferredAction(() => {
-            this.video.pause();
+            return this.video.pause();
         });
 	},
 


### PR DESCRIPTION
Fixes #341 .
 

Changes proposed in this pull request:
- return the returned `Promise` from `HTMLMediaElement.play` in `paella.Html5Video.play`

