### PR TITLE
Fix loop when seek throught a break in Safari for iOS

### DIFF
--- a/plugins/es.upv.paella.breakPlugins/player.js
+++ b/plugins/es.upv.paella.breakPlugins/player.js
@@ -110,7 +110,7 @@ paella.addPlugin(() => {
 							newTime = 0;
 							paella.player.videoContainer.pause();
 						} else {
-							newTime = br.e + (this.config.neverShow ? 0.01 : 0) - trimming.start;
+							newTime = br.e + (this.config.neverShow ? 0.5 : 0) - trimming.start;
 						}
 						paella.player.videoContainer.seekToTime(newTime);
 
@@ -122,7 +122,7 @@ paella.addPlugin(() => {
 							newTime = 0;
 							paella.player.videoContainer.pause();
 						} else {
-							newTime = br.e + (this.config.neverShow ? 0.01 : 0);
+							newTime = br.e + (this.config.neverShow ? 0.5 : 0);
 						}
 						paella.player.videoContainer.seekToTime(newTime);
 					});


### PR DESCRIPTION
Fixes #356 .
 

Changes proposed in this pull request:
- When seek to the end of the break add 0.5 seconds to avoid the break.

