### PR TITLE
hls plugin: handle nonfatal media errors

### DIFF
--- a/plugins/es.upv.paella.hlsPlayer/hls-player.js
+++ b/plugins/es.upv.paella.hlsPlayer/hls-player.js
@@ -53,7 +53,13 @@ Class ("paella.HLSPlayer", paella.Html5Video,{
 									if (console && console.log) console.log(`HLS: quality level changed to ${ data.level }`);
 								});
 								
-								This._hls.on(Hls.Events.ERROR, function (event, data) {
+							    This._hls.on(Hls.Events.ERROR, function (event, data) {
+									//deal with nonfatal media errors that might come from redirects after session expiration
+									if (data.type == Hls.ErrorTypes.MEDIA_ERROR) {
+											This._hls.destroy();
+											base.log.error("paella.HLSPlayer: Encountered invalid media file");
+											reject(new Error("invalid media"));
+									}
 									if (data.fatal) {
 										switch(data.type) {
 										case Hls.ErrorTypes.NETWORK_ERROR:


### PR DESCRIPTION
Please consider including error handling for non-fatal errors in the HLS plugin. If a media file is encountered which cannot be played due to unexpected content, paella player will loop and continue requesting the file indefinitely. Think about the case of having session timeouts for the media files. If the user's session expires, any request to a media file will redirect to the login page, resulting in a non-fatal media error.
