### PR TITLE
enable 2-stream videos on iOS >10

### DIFF
--- a/plugins/es.upv.paella.hlsPlayer/hls-player.js
+++ b/plugins/es.upv.paella.hlsPlayer/hls-player.js
@@ -203,7 +203,7 @@ Class ("paella.videoFactories.HLSVideoFactory", {
 		}
 		try {
 			if (paella.videoFactories.HLSVideoFactory.s_instances>0 && 
-				base.userAgent.system.iOS)
+				base.userAgent.system.iOS && paella.utils.userAgent.system.Version.major<=10)
 		//	In old iOS devices, playing more than one HLS stream may cause that the browser tab crash
 		//		&& (paella.utils.userAgent.system.Version.major<=10 && paella.utils.userAgent.system.Version.minor<3))
 			{


### PR DESCRIPTION
the hls plugin is currently hardwired to allow only a single stream on iOS devices for all versions of iOS. I don't know why the existing version check  was commented, though it is included in the build used for the 'HLS streaming test' on the demo page.
This commit re-enables the playback of 2-stream videos on iOS >10. I took the version number from the comment and did not investigate if it is correct.