### PR TITLE
The errorContainer has content overflow when height is fixed

### DIFF
--- a/resources/style/controls.less
+++ b/resources/style/controls.less
@@ -320,7 +320,7 @@ i.button-icon.icon-screen {
 
 .errorContainer {
     width: 55%;
-    height: 55%;
+    min-height: 55%;
     margin-top: 22%;
     position: relative;
     margin: auto;

--- a/src/02_video_utils.js
+++ b/src/02_video_utils.js
@@ -134,7 +134,7 @@ paella.videoFactory = {
 		if (paella.videoFactories) {
 			var This = this;
 			paella.player.config.player.methods.forEach(function(method) {
-				if (method.enabled) {
+				if (method.enabled && paella.videoFactories[method.factory]) {
 					This.registerFactory(new paella.videoFactories[method.factory]());
 				}
 			});


### PR DESCRIPTION
Fixes # errorContainer content overflow

Changes proposed in this pull request:
- change the fixed errorContainer height of 55% to be a min-height, so it will flexibly stretch around it's content.

See screen capture of fixed height of 55% versus flexible min-height:
![errorcontainerheight55percent](https://user-images.githubusercontent.com/1331728/47057696-d2163780-d18f-11e8-8ead-f93ad69db905.jpeg)
![errorcontainerminheight55percent](https://user-images.githubusercontent.com/1331728/47057699-d3dffb00-d18f-11e8-9e90-094cedb2cd8d.jpeg)



