### PR TITLE
Correctly format JSON in configuration file

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,53 +1,100 @@
 {
-  "player":{
-    "accessControlClass":"paella.AccessControl",
-        "profileFrameStrategy": "paella.ProfileFrameStrategy",
+  "player": {
+    "accessControlClass": "paella.AccessControl",
+    "profileFrameStrategy": "paella.ProfileFrameStrategy",
     "videoQualityStrategy": "paella.LimitedBestFitVideoQualityStrategy",
-    "videoQualityStrategyParams":{ "maxAutoQualityRes":720 },
+    "videoQualityStrategyParams": {
+      "maxAutoQualityRes": 720
+    },
     "reloadOnFullscreen": true,
     "videoZoom": {
-      "enabled":true,
-      "max":800,
-      "minWindowSize":500
+      "enabled": true,
+      "max": 800,
+      "minWindowSize": 500
     },
-
-    "deprecated-methods":[{"name":"streaming","enabled":true},
-           {"name":"html","enabled":true},
-           {"name":"flash","enabled":true},
-                   {"name":"image","enabled":true}],
-
-    "methods":[
-      { "factory":"ChromaVideoFactory", "enabled":true },
-      { "factory":"WebmVideoFactory", "enabled":true },
-      { "factory":"Html5VideoFactory", "enabled":true },
-      { "factory":"MpegDashVideoFactory", "enabled":true },
-      { "factory":"HLSVideoFactory", "enabled":true },
-      { "factory":"RTMPVideoFactory", "enabled":true },
-      { "factory":"ImageVideoFactory", "enabled":true },
-      { "factory":"YoutubeVideoFactory", "enabled":true },
-      { "factory":"Video360ThetaFactory", "enabled":true },
-      { "factory":"Video360Factory", "enabled":true }
+    "deprecated-methods": [
+      {
+        "name": "streaming",
+        "enabled": true
+      },
+      {
+        "name": "html",
+        "enabled": true
+      },
+      {
+        "name": "flash",
+        "enabled": true
+      },
+      {
+        "name": "image",
+        "enabled": true
+      }
     ],
-    "audioMethods":[
-      { "factory":"MultiformatAudioFactory", "enabled":true }
+    "methods": [
+      {
+        "factory": "ChromaVideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "WebmVideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "Html5VideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "MpegDashVideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "HLSVideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "RTMPVideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "ImageVideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "YoutubeVideoFactory",
+        "enabled": true
+      },
+      {
+        "factory": "Video360ThetaFactory",
+        "enabled": true
+      },
+      {
+        "factory": "Video360Factory",
+        "enabled": true
+      }
     ],
-        "rtmpSettings":{
-            "bufferTime":5,
+    "audioMethods": [
+      {
+        "factory": "MultiformatAudioFactory",
+        "enabled": true
+      }
+    ],
+    "rtmpSettings": {
+      "bufferTime": 5,
       "requiresSubscription": false
-        },
-    "slidesMarks":{
-      "enabled":true,
-      "color":"gray"
+    },
+    "slidesMarks": {
+      "enabled": true,
+      "color": "gray"
     }
   },
-  "defaultProfile":"presenter_presentation",
-  "data":{
-    "enabled":true,
-    "dataDelegates":{
-      "trimming":"CookieDataDelegate",
+  "defaultProfile": "presenter_presentation",
+  "data": {
+    "enabled": true,
+    "dataDelegates": {
+      "trimming": "CookieDataDelegate",
       "visualAnnotations": "VisualAnnotationsDataDelegate",
-      "metadata":"VideoManifestMetadataDataDelegate",
-      "cameraTrack":"TrackCameraDataDelegate"
+      "metadata": "VideoManifestMetadataDataDelegate",
+      "cameraTrack": "TrackCameraDataDelegate"
     }
   },
   "folders": {
@@ -55,112 +102,268 @@
     "resources": "resources",
     "skins": "resources/style"
   },
-  "experimental":{
-    "autoplay":true
+  "experimental": {
+    "autoplay": true
   },
-  "plugins":{
+  "plugins": {
     "enablePluginsByDefault": false,
-
-    "//**** Instructions: Disable any individual plugin by setting its enable property to false": {"enabled": false},
-    "//**** For a list of available plugins and configuration, go to": "https://github.com/polimediaupv/paella/blob/master/doc/plugins.md",
-    "list":{
-      "//******* Button plugins": "",
-      "edu.harvard.dce.paella.flexSkipPlugin": {"enabled":true, "direction": "Rewind", "seconds": 10},
-      "edu.harvard.dce.paella.flexSkipForwardPlugin": {"enabled":true, "direction": "Forward", "seconds": 30},
-      "es.upv.paella.captionsPlugin": {"enabled":true, "searchOnCaptions":true},
-      "es.upv.paella.extendedTabAdapterPlugin": {"enabled":true},
-      "es.upv.paella.footprintsPlugin": {"enabled":false},
-      "es.upv.paella.frameControlPlugin":  {"enabled": true, "showFullPreview": "auto", "showCaptions":true},
-      "es.upv.paella.fullScreenButtonPlugin": {"enabled":true, "reloadOnFullscreen":{ "enabled":true, "keepUserSelection":true }},
-      "es.upv.paella.helpPlugin": {"enabled":true, "langs":["en","es"]},
-      "es.upv.paella.multipleQualitiesPlugin": {"enabled":true, "showWidthRes":true},
-      "es.upv.paella.playbackRatePlugin": {"enabled":true, "availableRates": [0.75, 1, 1.25, 1.5]},
-      "es.upv.paella.playPauseButtonPlugin": {"enabled":true},
-      "es.upv.paella.searchPlugin": {"enabled":true, "sortType":"time", "colorSearch":false},
-      "es.upv.paella.socialPlugin": {"enabled":true},
-      "es.upv.paella.themeChooserPlugin":  {"enabled":true},
-      "es.upv.paella.viewModePlugin": { "enabled": true },
-      "es.upv.paella.volumeRangePlugin":{"enabled":true, "showMasterVolume": true, "showSlaveVolume": false },
-      "es.upv.paella.pipModePlugin": { "enabled":true },
-      "es.upv.paella.ratePlugin": { "enabled":true },
-      "es.upv.paella.videoZoomPlugin": { "enabled":true },
-      "es.upv.paella.audioSelector": { "enabled":true },
-      "es.upv.paella.videoZoomToolbarPlugin": { "enabled":false, "targetStreamIndex":0 },
-      "es.upv.paella.videoZoomTrack4kPlugin": { "enabled":true, "targetStreamIndex":0, "autoModeByDefault":false },
-      "es.upv.paella.airPlayPlugin": { "enabled":true },
-
-      "//***** Video Overlay Button Plugins": "",
-      "es.upv.paella.liveStreamingIndicatorPlugin":  { "enabled": true },
-      "es.upv.paella.showEditorPlugin":{"enabled":true,"alwaysVisible":true},
-      "es.upv.paella.arrowSlidesNavigatorPlugin": {"enabled": true, "showArrowsIn": "slave"},
+    "list": {
+      "edu.harvard.dce.paella.flexSkipPlugin": {
+        "enabled": true,
+        "direction": "Rewind",
+        "seconds": 10
+      },
+      "edu.harvard.dce.paella.flexSkipForwardPlugin": {
+        "enabled": true,
+        "direction": "Forward",
+        "seconds": 30
+      },
+      "es.upv.paella.captionsPlugin": {
+        "enabled": true,
+        "searchOnCaptions": true
+      },
+      "es.upv.paella.extendedTabAdapterPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.footprintsPlugin": {
+        "enabled": false
+      },
+      "es.upv.paella.frameControlPlugin": {
+        "enabled": true,
+        "showFullPreview": "auto",
+        "showCaptions": true
+      },
+      "es.upv.paella.fullScreenButtonPlugin": {
+        "enabled": true,
+        "reloadOnFullscreen": {
+          "enabled": true,
+          "keepUserSelection": true
+        }
+      },
+      "es.upv.paella.helpPlugin": {
+        "enabled": true,
+        "langs": [
+          "en",
+          "es"
+        ]
+      },
+      "es.upv.paella.multipleQualitiesPlugin": {
+        "enabled": true,
+        "showWidthRes": true
+      },
+      "es.upv.paella.playbackRatePlugin": {
+        "enabled": true,
+        "availableRates": [
+          0.75,
+          1,
+          1.25,
+          1.5
+        ]
+      },
+      "es.upv.paella.playPauseButtonPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.searchPlugin": {
+        "enabled": true,
+        "sortType": "time",
+        "colorSearch": false
+      },
+      "es.upv.paella.socialPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.themeChooserPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.viewModePlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.volumeRangePlugin": {
+        "enabled": true,
+        "showMasterVolume": true,
+        "showSlaveVolume": false
+      },
+      "es.upv.paella.pipModePlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.ratePlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.videoZoomPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.audioSelector": {
+        "enabled": true
+      },
+      "es.upv.paella.videoZoomToolbarPlugin": {
+        "enabled": false,
+        "targetStreamIndex": 0
+      },
+      "es.upv.paella.videoZoomTrack4kPlugin": {
+        "enabled": true,
+        "targetStreamIndex": 0,
+        "autoModeByDefault": false
+      },
+      "es.upv.paella.airPlayPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.liveStreamingIndicatorPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.showEditorPlugin": {
+        "enabled": true,
+        "alwaysVisible": true
+      },
+      "es.upv.paella.arrowSlidesNavigatorPlugin": {
+        "enabled": true,
+        "showArrowsIn": "slave"
+      },
       "es.upv.paella.videoDataPlugin": {
         "enabled": true,
-        "excludeLocations":[
+        "excludeLocations": [
           "paellaplayer.upv.es"
         ],
-        "excludeParentLocations":[
+        "excludeParentLocations": [
           "localhost:8000"
         ]
       },
       "es.upv.paella.legalPlugin": {
-		"enabled": true,
-		    "label": "Legal info",
-		    "position": "right",
+        "enabled": true,
+        "label": "Legal info",
+        "position": "right",
         "legalUrl": "https://en.wikipedia.org/wiki/General_Data_Protection_Regulation"
       },
-
-      "//***** TabBar Plugins": "",
-      "es.upv.paella.commentsPlugin": {"enabled": false},
-      "es.upv.paella.test.tabBarExamplePlugin": {"enabled": false},
-
-      "//**** Event Driven Plugins": "",
-      "es.upv.paella.blackBoardPlugin": {"enabled": true},
-      "es.upv.paella.breaksPlayerPlugin": {"enabled": true},
-      "es.upv.paella.overlayCaptionsPlugin": {"enabled": true},
-      "es.upv.paella.playButtonOnScreenPlugin": {"enabled":true},
-      "es.upv.paella.test.videoLoadPlugin": {"enabled":false},
-      "es.upv.paella.translecture.captionsPlugin": {"enabled":true},
-      "es.upv.paella.trimmingPlayerPlugin": {"enabled":true},
-      "es.upv.paella.zoomPlugin": {"enabled": false},
-      "es.upv.paella.windowTitlePlugin": {"enabled": true},
-      "es.upv.paella.track4kPlugin": { "enabled":true },
-
-      "//**** Video profile plugins": "",
-      "es.upv.paella.singleStreamProfilePlugin": {
-          "enabled": true,
-          "videoSets": [
-            { "icon":"professor_icon.svg", "id":"presenter", "content":["presenter"]},
-            { "icon":"slide_icon.svg", "id":"presentation", "content":["presentation"]}
-          ]
-
+      "es.upv.paella.commentsPlugin": {
+        "enabled": false
       },
-      "es.upv.paella.dualStreamProfilePlugin": { "enabled":true,
+      "es.upv.paella.test.tabBarExamplePlugin": {
+        "enabled": false
+      },
+      "es.upv.paella.blackBoardPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.breaksPlayerPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.overlayCaptionsPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.playButtonOnScreenPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.test.videoLoadPlugin": {
+        "enabled": false
+      },
+      "es.upv.paella.translecture.captionsPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.trimmingPlayerPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.zoomPlugin": {
+        "enabled": false
+      },
+      "es.upv.paella.windowTitlePlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.track4kPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.singleStreamProfilePlugin": {
+        "enabled": true,
         "videoSets": [
-          { "icon":"slide_professor_icon.svg", "id":"presenter_presentation", "content":["presenter","presentation"] },
-          { "icon":"slide_professor_icon.svg", "id":"presenter2_presentation", "content":["presenter-2","presentation"] },
-          { "icon":"slide_professor_icon.svg", "id":"presenter3_presentation", "content":["presenter-3","presentation"] }
+          {
+            "icon": "professor_icon.svg",
+            "id": "presenter",
+            "content": [
+              "presenter"
+            ]
+          },
+          {
+            "icon": "slide_icon.svg",
+            "id": "presentation",
+            "content": [
+              "presentation"
+            ]
+          }
+        ]
+      },
+      "es.upv.paella.dualStreamProfilePlugin": {
+        "enabled": true,
+        "videoSets": [
+          {
+            "icon": "slide_professor_icon.svg",
+            "id": "presenter_presentation",
+            "content": [
+              "presenter",
+              "presentation"
+            ]
+          },
+          {
+            "icon": "slide_professor_icon.svg",
+            "id": "presenter2_presentation",
+            "content": [
+              "presenter-2",
+              "presentation"
+            ]
+          },
+          {
+            "icon": "slide_professor_icon.svg",
+            "id": "presenter3_presentation",
+            "content": [
+              "presenter-3",
+              "presentation"
+            ]
+          }
         ]
       },
       "es.upv.paella.tripleStreamProfilePlugin": {
         "enabled": true,
         "videoSets": [
-          { "icon":"three_streams_icon.svg", "id":"presenter_presentation_presenter2", "content":["presenter","presentation","presenter-2"] },
-          { "icon":"three_streams_icon.svg", "id":"presenter_presentation_presenter3", "content":["presenter","presentation","presenter-3"] }
+          {
+            "icon": "three_streams_icon.svg",
+            "id": "presenter_presentation_presenter2",
+            "content": [
+              "presenter",
+              "presentation",
+              "presenter-2"
+            ]
+          },
+          {
+            "icon": "three_streams_icon.svg",
+            "id": "presenter_presentation_presenter3",
+            "content": [
+              "presenter",
+              "presentation",
+              "presenter-3"
+            ]
+          }
         ]
       },
-
-      "//****  Captions Parser Plugins": "",
-      "es.upv.paella.captions.DFXPParserPlugin": {"enabled":true},
-      "es.teltek.paella.captions.WebVTTParserPlugin": {"enabled":true},
-
-      "//****  Search Service Plugins": "",
-      "es.upv.paella.search.captionsSearchPlugin": {"enabled":true},
-      "es.upv.paella.frameCaptionsSearchPlugin": {"enabled":true},
-
-      "//****  User Tracking Saver Plugins": "",
-      "es.upv.paella.usertracking.elasticsearchSaverPlugin": { "enabled": false, "url": "http://my.elastic.server"},
-      "es.upv.paella.usertracking.GoogleAnalyticsSaverPlugIn": { "enabled": false, "trackingID": "UA-XXXXXXXX-Y" },
-      "es.upv.paella.usertracking.piwikSaverPlugIn": { "enabled": false, "tracker":"http://localhost/piwik/", "siteId": "1" },
+      "es.upv.paella.captions.DFXPParserPlugin": {
+        "enabled": true
+      },
+      "es.teltek.paella.captions.WebVTTParserPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.search.captionsSearchPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.frameCaptionsSearchPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.usertracking.elasticsearchSaverPlugin": {
+        "enabled": false,
+        "url": "http://my.elastic.server"
+      },
+      "es.upv.paella.usertracking.GoogleAnalyticsSaverPlugIn": {
+        "enabled": false,
+        "trackingID": "UA-XXXXXXXX-Y"
+      },
+      "es.upv.paella.usertracking.piwikSaverPlugIn": {
+        "enabled": false,
+        "tracker": "http://localhost/piwik/",
+        "siteId": "1"
+      },
       "org.opencast.usertracking.MatomoSaverPlugIn": {
         "enabled": false,
         "server": "http://localhost/piwik/",
@@ -168,13 +371,17 @@
         "heartbeat": 30,
         "client_id": "Paella Player"
       },
-      "es.teltek.paella.usertracking.xAPISaverPlugin": {"enabled": false, "endpoint":"http://localhost:8081/data/xAPI/", "auth":"auth_key"},
-
-      "//*****  Keyboard plugins": "",
-      "es.upv.paella.defaultKeysPlugin": {"enabled": true }
+      "es.teltek.paella.usertracking.xAPISaverPlugin": {
+        "enabled": false,
+        "endpoint": "http://localhost:8081/data/xAPI/",
+        "auth": "auth_key"
+      },
+      "es.upv.paella.defaultKeysPlugin": {
+        "enabled": true
+      }
     }
   },
-  "standalone" : {
+  "standalone": {
     "repository": "../repository/"
   },
   "skin": {


### PR DESCRIPTION
This addresses #374 

The JSON configuration file of the Paella player has many incorrect formattings. The goal of this task (it is neither a feature nor a bug) is to use a JSON formatter to get consistently formatted json.
I will use https://jsonformatter.org for this.

Also, the configuration file is working around the fact that JSON does not support comments. Most of the comments seem useless (how to disable/enable plugins is really obvious) or out-dated (e.g. reference to plugins.md on github which is a dead link).

It would be preferable to have the documentation separated and the individual plugins to be documented.

Note that this PR does not change any of the configuration settings. It just does...

- Format JSON using https://jsonformatter.org
- Remove "comments" in JSON