### PR TITLE
360 degree video playback does not work with signed URLs

### DIFF
--- a/plugins/es.upv.paella.video360Player/deps/bg2e.js
+++ b/plugins/es.upv.paella.video360Player/deps/bg2e.js
@@ -329,8 +329,12 @@ Reflect.defineProperty = Reflect.defineProperty || Object.defineProperty;
     function Resource() {}
     return ($traceurRuntime.createClass)(Resource, {}, {
       GetExtension: function(url) {
-        var match = /\.([a-z0-9-_]*)$/i.exec(url);
-        return (match && match[1].toLowerCase()) || "";
+        var filename = url.substring(url.lastIndexOf("/") + 1).split("?")[0].toLowerCase();
+        if (filename.indexOf(".") > 0) {
+          return filename.split(".").pop().toLowerCase();
+        } else {
+          return "";
+        }
       },
       IsFormat: function(url, formats) {
         return formats.find(function(fmt) {

--- a/plugins/es.upv.paella.video360PlayerTheta/deps/bg2e.js
+++ b/plugins/es.upv.paella.video360PlayerTheta/deps/bg2e.js
@@ -329,8 +329,12 @@ Reflect.defineProperty = Reflect.defineProperty || Object.defineProperty;
     function Resource() {}
     return ($traceurRuntime.createClass)(Resource, {}, {
       GetExtension: function(url) {
-        var match = /\.([a-z0-9-_]*)$/i.exec(url);
-        return (match && match[1].toLowerCase()) || "";
+        var filename = url.substring(url.lastIndexOf("/") + 1).split("?")[0].toLowerCase();
+        if (filename.indexOf(".") > 0) {
+          return filename.split(".").pop().toLowerCase();
+        } else {
+          return "";
+        }
       },
       IsFormat: function(url, formats) {
         return formats.find(function(fmt) {


### PR DESCRIPTION
Using signed URLs for 360 degree video resources does not work because the method GetExtension fails to extract the file extension if query string parameters are present.

#### What is the current behavior? (You can also link to an open issue here)
The file extension is not extracted correctly if query string parameters are present

#### What does this implement/fix? Explain your changes.
It fixes the extraction of the file extension from a given URL in the plugins Video360Player and Video360PlayerTheta.

#### Does this close any currently open issues?
close #391 
