### PR TITLE
added missing base url to hls and mpeg dash load.

### DIFF
--- a/plugins/es.upv.paella.hlsPlayer/hls-player.js
+++ b/plugins/es.upv.paella.hlsPlayer/hls-player.js
@@ -86,7 +86,7 @@
 		_loadDeps() {
 			return new Promise((resolve,reject) => {
 				if (!window.$paella_hls) {
-					require(['resources/deps/hls.min.js'],function(hls) {
+					require([paella.baseUrl +'resources/deps/hls.min.js'],function(hls) {
 						window.$paella_hls = hls;
 						resolve(window.$paella_hls);
 					});

--- a/plugins/es.upv.paella.mpegDashPlayer/mpeg-dash-player.js
+++ b/plugins/es.upv.paella.mpegDashPlayer/mpeg-dash-player.js
@@ -12,7 +12,7 @@ class MpegDashVideo extends paella.Html5Video {
 	_loadDeps() {
 		return new Promise((resolve,reject) => {
 			if (!window.$paella_mpd) {
-				require(['resources/deps/dash.all.js'],function() {
+				require([paella.baseUrl +'resources/deps/dash.all.js'],function() {
 					window.$paella_mpd = true;
 					resolve(window.$paella_mpd);
 				});


### PR DESCRIPTION
If you place paella not inside the root web directory, for example like "/paella/", require will not find the hls.js or dash.all.js because its looking for /resources/[...] and not /paella/resources/[...].

I added for both plugins paella.baseUrl as it is in the croma-player plugin (https://github.com/polimediaupv/paella/blob/35172d99f948aa6316de901751fada8e3a448270/plugins/es.upv.paella.chromaPlayer/chroma-player.js#L226) or the video360 plugin (https://github.com/polimediaupv/paella/blob/35172d99f948aa6316de901751fada8e3a448270/plugins/es.upv.paella.video360Player/video360.js#L194)

This bug exists also in the version 5.3.x and 6.0.x.


