### PR TITLE
Re-enable start and end param option, fix for #403

### DIFF
--- a/plugins/es.upv.paella.TrimmingPlugins/trimming_player.js
+++ b/plugins/es.upv.paella.TrimmingPlugins/trimming_player.js
@@ -38,9 +38,9 @@ paella.addPlugin(function() {
 					var startTime =  base.parameters.get('start');
 					var endTime = base.parameters.get('end');
 					if (startTime && endTime) {
-						paella.player.videoContainer.enableTrimming();
-						paella.player.videoContainer.setTrimming(startTime, endTime)
-							.then(() => {} )
+						paella.player.videoContainer.setTrimming(startTime, endTime).then(function() {
+							return paella.player.videoContainer.enableTrimming();
+						});
 					}
 				}
 			});


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This is a bug fix for the optional start & end url param feature.

#### What is the current behavior? (You can also link to an open issue here)
Currently, start & end Url query params are bypassed and not used.

#### What does this implement/fix? Explain your changes.
The issue was introduced in a past refactoring (3+ previous iterations of these lines) where the enableTrimming was able to be executed before the setTrimming changes were complete. This pull reverts the order of execution to its original state to ensure that setTrimming's promise is resolved before enableTrimming is executed. 

#### Does this close any currently open issues?
close #403 

#### Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
This does not introduce a breaking change. Although, I do not know the reason why these lines were originally refactored to the different order.

#### Any other comments?
I admit that I did not test that "paella.data.read('trimming'.." option above the start & end url params. I notice that it has the same execution ordering that does not work for the start & end params.