### PR TITLE
Update Travis CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,20 @@
-sudo: required
-
-services:
-  - docker
-  
 language: node_js
 
 node_js:
   - "lts/*"
-  
-before_install:
-
 
 install:
-  - sudo apt-get install -y jq
-  - npm install -g gulp
   - npm install
-
 
 jobs:
   include:
-    - stage: Tests
+    - stage: tests
       script:
         - npm run markdownlint
 
     - stage: build and deploy
       script:
         - npm run build
-        #- gulp build.debug
-        #- docker run -d --name paella-test-nginx -v `pwd`/build:/usr/share/nginx/html:ro nginx:alpine
-        #- docker run -d --name paella-test-selenium --link paella-test-nginx:paella -p 4444:4444 selenium/standalone-chrome:3.3.0
-        #- gulp test:local
       before_deploy:
         - export PRERELEASE=$(bash ./.publish_scripts/is_prerelease_version.sh ${TRAVIS_TAG})
       deploy:


### PR DESCRIPTION
This patch updates the Travis CI configuration. It removes all unnecessary steps including the manual install of `jq` since that package is already present on Travis (see listings of package versions at the beginning).