### PR TITLE
Caption Search Update for the lunr dependency version change

### DIFF
--- a/src/06_1_captions.js
+++ b/src/06_1_captions.js
@@ -151,10 +151,7 @@ class Caption {
 		this._format = format;
 		this._url = url;
 		this._captions = undefined;
-		this._index = lunr(function () {
-			this.ref('id');
-			this.field('content', {boost: 10});
-		});
+		this._index = undefined;
 		
 		if (typeof(lang) == "string") { lang = {code: lang, txt: lang}; }
 		this._lang = lang;
@@ -201,17 +198,21 @@ class Caption {
 				parser.parse(dataRaw, self._lang.code, function(err, c) {
 					if (!err) {
 						self._captions = c;
-						
-						self._captions.forEach(function(cap){
-							self._index.add({
-								id: cap.id,
-								content: cap.content,
-							});				
-						});							
+						self._index = lunr(function () {
+							var thisLunr = this;
+							thisLunr.ref('id');
+							thisLunr.field('content', {boost: 10});
+							self._captions.forEach(function(cap){
+								thisLunr.add({
+									id: cap.id,
+									content: cap.content,
+								});
+							});
+						});
 					}
-					if (next) { next(err); }						
+					if (next) { next(err); }
 				});
-			}			
+			}
 		})
 		.fail(function(error){
 			base.log.debug("Error loading captions: " + self._url);


### PR DESCRIPTION

<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This change fixes the Caption Plugin search capability.

#### What is the current behavior? (You can also link to an open issue here)
The recent paella package.json upgrade updated Paella player's lunr dependency from v0x to v2x.
https://github.com/polimediaupv/paella/blob/develop/package.json#L40
  "lunr": "^2.3.6",
https://github.com/polimediaupv/paella/commit/ec5e010b1bdf3ce9ec5b35193754e53b2944be73

From the lunrjs upgrade page: "The largest difference between 0.x/1.x and 2.x is that Lunr indexes are now immutable." https://lunrjs.com/guides/upgrading.html

#### What does this implement/fix? Explain your changes.
This pull updates the caption parse for the lunr upgrade.

#### Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
This PR is for the develop branch that has the lunr 2x package dependency, the earlier Paella version have the older lunr and the correct format.

