### PR TITLE
keys plugin mute (and only mute) key M press fix

### DIFF
--- a/plugins/es.upv.paella.keyPlugin/main.js
+++ b/plugins/es.upv.paella.keyPlugin/main.js
@@ -67,12 +67,7 @@ paella.addPlugin(() => {
 		}
 	
 		mute() {
-			var videoContainer = paella.player.videoContainer;
-			videoContainer.volume().then(function(volume){
-				var newVolume = 0;
-				if (volume==0) { newVolume = 1.0; }
-				paella.player.videoContainer.setVolume({ master:newVolume, slave: 0});
-			});
+			paella.player.videoContainer.setVolume(0);
 		}
 	
 		volumeUp() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This pull enables the alt + 'M' keystroke to mute, and only mute, the volume. It doesn't unmute because it can't easily get to the _preMutedVolume attribute of the volume plugin, and it doesn't want to scare the user an unexpected full 1.0 volume. 

#### What is the current behavior? (You can also link to an open issue here)
The keystroke M mute doesn't mute and gets a console.warn("videoContainer.setVolume(): set parameter as object is deprecated") because M still sends the master-slave volume object.

#### What does this implement/fix? Explain your changes.
This pull sends a value instead of an object to setVolume.

#### Does this close any currently open issues?
I  don't see the issue reported yet.

#### Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
No known breaking change from this pull.
