### PR TITLE
Issue #447 synch videos to mainAudioPlayer time

### DIFF
--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -1004,9 +1004,21 @@ class Html5Video extends paella.VideoElementBase {
 	enable(isMainAudioPlayer) {
 		//if (isMainAudioPlayer) return;
 		//this._isDisabled = false;
-		//if (this._playState) {
-		//	this.video.play();
-		//}
+		//let This = this;
+		//paella.player.videoContainer.masterVideo().getVideoData().then(function (videoData) {
+		//	let currentTime = videoData.currentTime;
+		//	let paused = videoData.paused;
+		//	paella.player.videoContainer.seekToTime(currentTime);
+		//	if (paused) {
+		//		if (This._playState) {
+		//			base.log.debug(`Video '${This.video.id}' was playing, but leaving it in paused state like the main video.`)
+		//		}
+		//		// and make sure it's really paused
+		//		This.video.pause();
+		//	} else {
+		//		This.video.play();
+		//	}
+		//});
 	}
 
 	getQualities() {

--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -1002,13 +1002,15 @@ class Html5Video extends paella.VideoElementBase {
 	}
 
 	enable(isMainAudioPlayer) {
-		//if (isMainAudioPlayer) return;
+		//if (isMainAudioPlayer || !this._isDisabled) return;
 		//this._isDisabled = false;
 		//let This = this;
 		//paella.player.videoContainer.masterVideo().getVideoData().then(function (videoData) {
 		//	let currentTime = videoData.currentTime;
 		//	let paused = videoData.paused;
-		//	paella.player.videoContainer.seekToTime(currentTime);
+		//	let shorttime = parseFloat(currentTime).toFixed(3);
+		//	if (shorttime < 0.1) shorttime = 0.1; //iOS protection
+		//	paella.player.videoContainer.seekToTime(shorttime);
 		//	if (paused) {
 		//		if (This._playState) {
 		//			base.log.debug(`Video '${This.video.id}' was playing, but leaving it in paused state like the main video.`)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR adds a video sync update check to the video container's existing time update event.
It causes the video container to update videos to the timestamp of the main audio player when they fall out of synch by 0.3 seconds. The "syncVideo" method is based on Paella Player 5x syncVideo method, that is not in Paella Player 6x.

## What is the current behavior? (You can also link to an open issue here)
Long and large multiple videos get out of time synchronization with the main audio player after playing for a while together. Might require a slightly unreliable network to see the effect. It also helps to test with 2 of the same video of a person talking to the screen loaded as master and as slave.

## What does this implement/fix? Explain your changes.
The pull forces the two videos to stay within 0.3 seconds of time with each other (except when the slave video (the non-main-audio-player video) is paused). There is commented out code in the 03 file where changing the profile can re-enable a disabled slave video  and does a general wide seekTo on the container to force videos to be at the same time, paused or not, master or not.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
closes #447

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
Unknown what might break from this PR. Have only tested it with HTML5 videos.

## Any other comments?
[EDIT] Added promises back in for setting the slave currentTime and ensured they only happen one at a time.

Improvements and comments are gratefully accepted! This is an iteration we are testing for our production release.
