### PR TITLE
Play/pause button on screen now shows when video reaches end

### DIFF
--- a/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
+++ b/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
@@ -103,6 +103,7 @@ paella.addPlugin(function() {
 	
 		endVideo() {
 			this.isPlaying = false;
+			this.showIcon = true;
 			this.checkStatus();
 		}
 	


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Shows the playbutton on screen image, if it can, and the video ends. 
It is a compliment for #408 


## What is the current behavior? (You can also link to an open issue here)\
The video ends, the play-pause button shows play, but the playbuttonOnScreen does not show up. The screen can be clicked to start the video.

## What does this implement/fix? Explain your changes.
Shows the play button on screen when the video ends and can be played.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
compliments #408 

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
no


## Any other comments?
no
