### PR TITLE
Allow setting video time to zero

### DIFF
--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -1120,7 +1120,7 @@ class Html5Video extends paella.VideoElementBase {
 
 	setCurrentTime(time) {
 		return this._deferredAction(() => {
-			time && !isNaN(time) && (this.video.currentTime = time);
+			(time == 0 || time) && !isNaN(time) && (this.video.currentTime = time);
 		});
 	}
 


### PR DESCRIPTION
This pull allows a video to be set to time zero (0) in browsers like Safari that evaluate 0 as false.

The existing conditional for setting a video's current time evaluates time to "false" when it should be evaluated as the number 0. That prevents setting the video to time 0. 

No known breaking changes from this pull. HOWEVER, I vaguely recall in the past that some browsers had issues setting a video's time to 0. This fix might cause problems for those browsers by removing that protection of preventing setting a video to time 0.