### PR TITLE
PlayButonOnScreen event race condition between trimmed end and replay

### DIFF
--- a/plugins/es.upv.paella.TrimmingPlugins/trimming_player.js
+++ b/plugins/es.upv.paella.TrimmingPlugins/trimming_player.js
@@ -38,9 +38,10 @@ paella.addPlugin(function() {
 					var startTime =  base.parameters.get('start');
 					var endTime = base.parameters.get('end');
 					if (startTime && endTime) {
-						paella.player.videoContainer.setTrimming(startTime, endTime).then(function() {
-							return paella.player.videoContainer.enableTrimming();
-						});
+						paella.player.videoContainer.enableTrimming();
+						paella.player.videoContainer.setTrimming(startTime, endTime)
+							.then(() => {})
+
 					}
 				}
 			});

--- a/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
+++ b/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
@@ -31,11 +31,19 @@ paella.addPlugin(function() {
 		}
 	
 		getEvents() {
-			return [paella.events.endVideo,paella.events.play,paella.events.pause,paella.events.showEditor,paella.events.hideEditor];
+			return [
+				paella.events.ended,
+				paella.events.endVideo,
+				paella.events.play,
+				paella.events.pause,
+				paella.events.showEditor,
+				paella.events.hideEditor
+			];
 		}
 	
 		onEvent(eventType,params) {
 			switch (eventType) {
+				case paella.events.ended:
 				case paella.events.endVideo:
 					this.endVideo();
 					break;
@@ -60,9 +68,16 @@ paella.addPlugin(function() {
 		}
 	
 		endVideo() {
-			this.isPlaying = false;
-			this.showIcon = this.showOnEnd;
-			this.checkStatus();
+			paella.player.videoContainer.ended()
+			.then(ended => {
+				if (ended) {
+					this.isPlaying = false;
+					this.showIcon = this.showOnEnd;
+					this.checkStatus();
+				} else {
+					base.log.debug(`BTN ON SCREEN: The player is not currently in ended state, not changing button state.`);
+				}
+			});
 		}
 	
 		play() {

--- a/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
+++ b/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
@@ -75,7 +75,7 @@ paella.addPlugin(function() {
 					this.showIcon = this.showOnEnd;
 					this.checkStatus();
 				} else {
-					base.log.debug(`BTN ON SCREEN: The player is not currently in ended state, not changing button state.`);
+					base.log.debug(`BTN ON SCREEN: The player is no longer in ended state.`);
 				}
 			});
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This is a bug fix for the play button on screen endVideo behavior when there is a trimming-end.
1. It adds the ended event to the plugin to handle trimmed end times.
2. It prevents the handler of the ended event from overriding state when there is a replay "play" event race condition.

## What is the current behavior? (You can also link to an open issue here)

A) When there is a soft trimmed end for the player, the video element does not throw an "end" event, so the "endVideo" event is not triggered. [1]. The soft trim ending comes from comparison of the current time to the trimmed duration [2]. The button on screen does not listen for the "end" event of the soft trim, only the "endVideo" event that originates from the video element.

RESULT: The play button on  screen does not appear when the trimmed event ends.

B) When the "end" event is added to the play-button-on-screen, it appears when the trimmed video ends, but there is a race condition with the "play" event.

The soft trim "end" event is triggered after a delay of 1000 ms. [2]. The video container's play() play event is triggered after a delay of 50ms. [3]. The play-button-on-screen handles the play event before it handles the end event. The result is that the videos are playing and the play icon is on the screen.

To test this race condition: add "end" as a listened event in the plugin, add a soft trim "&start=10&end=40" to the url of the player, reload the browser, click "flex skip forward" repeatedly past the end of the video to trigger the end event and also quickly trigger the play event. 

RESULT: The play button on screen icon is visible while the videos are playing.

C) This pull adds the "end" event and also checks if the video container is an ended state before handling the end and endVideo event(s).

[1] https://github.com/polimediaupv/paella/blob/6.3.1/src/03_video_nodes.js#L844-L845
[2] https://github.com/polimediaupv/paella/blob/6.3.1/src/04_video_container.js#L1312-L1320
[3] https://github.com/polimediaupv/paella/blob/develop/src/04_video_container.js#L368-L372
