### PR TITLE
Add video title to Matomo tracking events

### DIFF
--- a/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
+++ b/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
@@ -84,28 +84,28 @@ paella.addPlugin(function() {
 
         switch (event) {
           case paella.events.play:
-            paella.userTracking.matomotracker.trackEvent("Player.Controls","Play");
+            paella.userTracking.matomotracker.trackEvent("Player.Controls","Play", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.pause:
-            paella.userTracking.matomotracker.trackEvent("Player.Controls","Pause");
+            paella.userTracking.matomotracker.trackEvent("Player.Controls","Pause", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.endVideo:
-            paella.userTracking.matomotracker.trackEvent("Player.Status","Ended");
+            paella.userTracking.matomotracker.trackEvent("Player.Status","Ended", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.showEditor:
-            paella.userTracking.matomotracker.trackEvent("Player.Editor","Show");
+            paella.userTracking.matomotracker.trackEvent("Player.Editor","Show", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.hideEditor:
-            paella.userTracking.matomotracker.trackEvent("Player.Editor","Hide");
+            paella.userTracking.matomotracker.trackEvent("Player.Editor","Hide", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.enterFullscreen:
-            paella.userTracking.matomotracker.trackEvent("Player.View","Fullscreen");
+            paella.userTracking.matomotracker.trackEvent("Player.View","Fullscreen", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.exitFullscreen:
-            paella.userTracking.matomotracker.trackEvent("Player.View","ExitFullscreen");
+            paella.userTracking.matomotracker.trackEvent("Player.View","ExitFullscreen", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.loadComplete:
-            paella.userTracking.matomotracker.trackEvent("Player.Status","LoadComplete");
+            paella.userTracking.matomotracker.trackEvent("Player.Status","LoadComplete", paella.loaderFunctionParams.videoLoader.metadata.title);
             break;
           case paella.events.showPopUp:
             paella.userTracking.matomotracker.trackEvent("Player.PopUp","Show", value);

--- a/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
+++ b/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
@@ -69,6 +69,12 @@ paella.addPlugin(function() {
       }
     }
 
+    loadTitle() {
+      var title = paella.player.videoLoader.getMetadata() && paella.player.videoLoader.getMetadata().title;
+      document.title = title || document.title;
+      return document.title;
+    }
+
     log(event, params) {
       if (paella.userTracking.matomotracker === undefined) {
         base.log.debug("Matomo Tracker is missing");
@@ -84,28 +90,28 @@ paella.addPlugin(function() {
 
         switch (event) {
           case paella.events.play:
-            paella.userTracking.matomotracker.trackEvent("Player.Controls","Play", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.Controls","Play", this.loadTitle());
             break;
           case paella.events.pause:
-            paella.userTracking.matomotracker.trackEvent("Player.Controls","Pause", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.Controls","Pause", this.loadTitle());
             break;
           case paella.events.endVideo:
-            paella.userTracking.matomotracker.trackEvent("Player.Status","Ended", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.Status","Ended", this.loadTitle());
             break;
           case paella.events.showEditor:
-            paella.userTracking.matomotracker.trackEvent("Player.Editor","Show", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.Editor","Show", this.loadTitle());
             break;
           case paella.events.hideEditor:
-            paella.userTracking.matomotracker.trackEvent("Player.Editor","Hide", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.Editor","Hide", this.loadTitle());
             break;
           case paella.events.enterFullscreen:
-            paella.userTracking.matomotracker.trackEvent("Player.View","Fullscreen", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.View","Fullscreen", this.loadTitle());
             break;
           case paella.events.exitFullscreen:
-            paella.userTracking.matomotracker.trackEvent("Player.View","ExitFullscreen", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.View","ExitFullscreen", this.loadTitle());
             break;
           case paella.events.loadComplete:
-            paella.userTracking.matomotracker.trackEvent("Player.Status","LoadComplete", paella.loaderFunctionParams.videoLoader.metadata.title);
+            paella.userTracking.matomotracker.trackEvent("Player.Status","LoadComplete", this.loadTitle());
             break;
           case paella.events.showPopUp:
             paella.userTracking.matomotracker.trackEvent("Player.PopUp","Show", value);

--- a/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
+++ b/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
@@ -71,8 +71,7 @@ paella.addPlugin(function() {
 
     loadTitle() {
       var title = paella.player.videoLoader.getMetadata() && paella.player.videoLoader.getMetadata().title;
-      document.title = title || document.title;
-      return document.title;
+      return title;
     }
 
     log(event, params) {


### PR DESCRIPTION
Hi, I've added the video title in the event that is sended to Matomo tracking, so that it would receive a more complete information about what it's tracking.

I hope it'll be an interesting improve of this plugin.