### PR TITLE
DFXP caption parse fix for jQuery v3.5.0 upgrade

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+* TBD
+
+  * DFXP caption parse fix for jQuery 5.3.0 upgrade
+
 * Paella 6.4.2
 
   * Fixed a bug in HLS videos that occurs when the connection is slow.

--- a/plugins/es.upv.paella.captions.DFXPParserPlugin/dfxp_parser.js
+++ b/plugins/es.upv.paella.captions.DFXPParserPlugin/dfxp_parser.js
@@ -9,7 +9,8 @@ paella.addPlugin(function() {
 		parse(content, lang, next) {
 			var captions = [];
 			var self = this;
-			var xml = $(content);
+			var xmlDoc = $.parseXML(content);
+			var xml = $(xmlDoc);
 			var g_lang = xml.attr("xml:lang");
 			
 			var lls = xml.find("div");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce?
This is a bug fix to enable the the DFXP Caption parser to be compatible with jQuery v3.5.0. It affects projects that use Paella as an npm dependency where Paella has ^3.4.1 version wiggle room in it's package.json and no npm-shrinkwrap.json file.

## What is the current behavior?
The "div" attribute of the DFXP file is not found after the upgrade from jQuery v3.4.1 to v3.5.0. The captions are no longer parsed and accessible to the caption plugins.

## What does this implement/fix?
It fixes parsing captions from a DFXP caption file.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
This pull does not fix currently open issues. It is related to pull #448 for projects that use Paella as an npm dependency, there is no npm-shrinkwrap file to mirror the packagae-lock file. This issue is new for projects that use Paella because jQuery 3.5.0 was just released 12 days ago, April 10, 2020. 

"jQuery 3.5.0 Released!" Posted on April 10, 2020 by Timmy Willison
https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
In theory, this fix should be backwards compatible with jQuery v3.4.1, but I have not verified this.

## Any other comments?
Paella references that pull in  jQuery 3.5.0 (Note that package-lock.json does not protect projects that build with a Paella dependency in it's package.json)
https://github.com/polimediaupv/paella/blob/6.4.x/package.json#L41
https://github.com/polimediaupv/paella/pull/533
