### PR TITLE
Feature to add default resolution quality as URL param or as config

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,9 +1,13 @@
 {
   "player":{
     "accessControlClass":"paella.AccessControl",
-        "profileFrameStrategy": "paella.ProfileFrameStrategy",
-    "videoQualityStrategy": "paella.LimitedBestFitVideoQualityStrategy",
-    "videoQualityStrategyParams":{ "maxAutoQualityRes":720 },
+    "profileFrameStrategy": "paella.ProfileFrameStrategy",
+    "videoQualityStrategy": "paella.BestFitVideoQualityStrategy",
+    "videoQualityStrategyParams":{
+      "maxAutoQualityRes":720,
+      "*** Default quality level override options are low or high, leave blank for strategy to decide": "",
+      "defaultQualityLevel": ""
+    },
     "reloadOnFullscreen": true,
     "videoZoom": {
       "enabled":true,

--- a/doc/developers/url_parameters.md
+++ b/doc/developers/url_parameters.md
@@ -13,6 +13,8 @@ By default, Paella Player accepts the following parameters in the URL:
 - `log`: Log level by the console (`error`, `warn`, `debug`, `log`)
 - `disable-ui`: It prevents the user interface from loading, as well as plugins that depend on the user interface.
 - `muted`: It starts playback without volume, which allows the `autoplay` parameter to work in browsers where it would otherwise not work.
+- `res`: Override video quality strategy classes to load the highest or lowest video resolution available (`high`, `low`)
+- `start` & `end`: both params needed together to trim start and end time in seconds.
 
 There is a way to generate a video manifest from the URL parameters, with up to two streams, using the following parameters:
 

--- a/src/01_utils.js
+++ b/src/01_utils.js
@@ -498,16 +498,16 @@ paella.utils.uuid = function() {
             logLevelParam = logLevelParam.toLowerCase();
             switch (logLevelParam) {
                 case "error":
-                    this.setLevel(paella.log.kLevelError);
+                    this.setLevel(Log.kLevelError);
                     break;
                 case "warning":
-                    this.setLevel(paella.log.kLevelWarning);
+                    this.setLevel(Log.kLevelWarning);
                     break;
                 case "debug":
-                    this.setLevel(paella.log.kLevelDebug);
+                    this.setLevel(Log.kLevelDebug);
                     break;
                 case "log":
-                    this.setLevel(paella.log.kLevelLog);
+                    this.setLevel(Log.kLevelLog);
                     break;
             }
         }
@@ -517,18 +517,18 @@ paella.utils.uuid = function() {
             if (typeof(level)=="string") {
                 message = level;
             }
-            else if (level>=paella.log.kLevelError && level<=paella.log.kLevelLog) {
+            else if (level>=Log.kLevelError && level<=Log.kLevelLog) {
                 switch (level) {
-                    case paella.log.kLevelError:
+                    case Log.kLevelError:
                         prefix = "ERROR: ";
                         break;
-                    case paella.log.kLevelWarning:
+                    case Log.kLevelWarning:
                         prefix = "WARNING: ";
                         break;
-                    case paella.log.kLevelDebug:
+                    case Log.kLevelDebug:
                         prefix = "DEBUG: ";
                         break;
-                    case paella.log.kLevelLog:
+                    case Log.kLevelLog:
                         prefix = "LOG: ";
                         break;
                 }
@@ -540,19 +540,19 @@ paella.utils.uuid = function() {
         }
     
         error(message) {
-            this.logMessage(paella.log.kLevelError, message);
+            this.logMessage(Log.kLevelError, message);
         }
     
         warning(message) {
-            this.logMessage(paella.log.kLevelWarning, message);
+            this.logMessage(Log.kLevelWarning, message);
         }
     
         debug(message) {
-            this.logMessage(paella.log.kLevelDebug, message);
+            this.logMessage(Log.kLevelDebug, message);
         }
     
         log(message) {
-            this.logMessage(paella.log.kLevelLog, message);
+            this.logMessage(Log.kLevelLog, message);
         }
     
         setLevel(level) {

--- a/src/02_video_utils.js
+++ b/src/02_video_utils.js
@@ -17,6 +17,12 @@
 
 (function() {
 	class VideoQualityStrategy {
+
+		constructor() {
+			this.defaultLevelOptions = ["low", "high"];
+			this.defaultLevel = null;
+		}
+
 		static Factory() {
 			var config = paella.player.config;
 
@@ -25,6 +31,7 @@
 				var ClassObject = paella.utils.objectFromString(strategyClass);
 				var strategy = new ClassObject();
 				if (strategy instanceof paella.VideoQualityStrategy) {
+					paella.log.debug("Loading strategy  '" + strategy.constructor.name);
 					return strategy;
 				}
 			}
@@ -46,6 +53,63 @@
 				return source;
 			}
 		}
+
+		// Default quality priority goes to the URL "res" param first,
+		// then to the config "defaultQualityLevel" param.
+		// If there is no default quality level, the best
+		// fit algorythnms make a quality choice on initial load.
+		getDefaultLevel() {
+			if (this.defaultLevel) {
+			    return this.defaultLevel;
+			}
+			var dLevel = paella.utils.parameters.get('res');
+			if (!dLevel) {
+				var params = this.getParams();
+				dLevel = params.defaultQualityLevel || null;
+			}
+			// validate the value
+			if (this.defaultLevelOptions.includes(dLevel)) {
+				this.defaultLevel = dLevel;
+			}
+			return this.defaultLevel;
+		}
+
+		getDefaultLevelIndex(source, defaultQuality, maxHeightRes) {
+			var index;
+			if (this.defaultLevelOptions.includes(defaultQuality) && source.length>0) {
+				// assume an unsorted source list
+				var lowest = 0, highest = 0;
+				var lowest_res = null;
+				var highest_res = null;
+				for (var i=0; i<source.length; ++i) {
+					var selected = source[i];
+					if (selected.res && selected.res.w && selected.res.h) {
+						var selected_res = parseInt(selected.res.w) * parseInt(selected.res.h);
+						if (!lowest_res) { // init the low and high res
+							lowest_res = parseInt(selected.res.w) * parseInt(selected.res.h);
+							highest_res = parseInt(selected.res.w) * parseInt(selected.res.h);
+						}
+						var isOkHeight  = maxHeightRes ? selected.res.h <= maxHeightRes : true;
+						if (highest_res < selected_res && isOkHeight) {
+							highest = i;
+							highest_res = selected_res;
+						} else if (lowest_res > selected_res) {
+							lowest = i;
+							lowest_res = selected_res;
+						}
+					}
+				}
+				if (defaultQuality === "low") {
+					index = lowest;
+				} else {
+					index = highest;
+				}
+			} else {
+				// Default index when all other is unknown
+				index = source.length - 1;
+			}
+			return index;
+		}
 	}
 
 	paella.VideoQualityStrategy = VideoQualityStrategy;
@@ -53,6 +117,13 @@
 	class BestFitVideoQualityStrategy extends paella.VideoQualityStrategy {
 		getQualityIndex(source) {
 			var index = source.length - 1;
+			// Test for default quality override
+			var defaultQuality = this.getDefaultLevel();
+
+			if (this.defaultLevelOptions.includes(defaultQuality) && source.length>0) {
+				var noMaxResLimit  = null;
+				return this.getDefaultLevelIndex(source, defaultQuality, noMaxResLimit);
+			}
 	
 			if (source.length>0) {
 				var selected = source[0];
@@ -78,7 +149,6 @@
 					}
 				}
 			}
-	
 			return index;
 		}
 	}
@@ -89,6 +159,13 @@
 		getQualityIndex(source) {
 			var index = source.length - 1;
 			var params = this.getParams();
+			// Test for default quality override
+			var defaultQuality = this.getDefaultLevel();
+
+			var maxRes = params.maxAutoQualityRes || 720;
+			if (this.defaultLevelOptions.includes(defaultQuality) && source.length>0) {
+				return this.getDefaultLevelIndex(source, defaultQuality, maxRes);
+			}
 	
 			if (source.length>0) {
 				//var selected = source[0];

--- a/src/09_paella_player.js
+++ b/src/09_paella_player.js
@@ -198,7 +198,7 @@
 					var videoQualityStrategy = new paella.BestFitVideoQualityStrategy();
 					try {
 						var StrategyClass = this.config.player.videoQualityStrategy;
-						var ClassObject = paella.utils.classFromString(StrategyClass);
+						var ClassObject = paella.utils.objectFromString(StrategyClass);
 						videoQualityStrategy = new ClassObject();
 					}
 					catch(e) {

--- a/tests/nightwatch/tests/testExtendedTabAdapterButton/testExtendedTabAdapterButton.js
+++ b/tests/nightwatch/tests/testExtendedTabAdapterButton/testExtendedTabAdapterButton.js
@@ -4,7 +4,7 @@ module.exports = {
         .url("http://localhost:8000/player/index.html?id=video-remote-1")
         .waitForElementVisible('body', 1000)
         .assert.visible('.play-icon')
-        .click('.videoWrapper')
+        .click('#playerContainer_videoContainer')
         .waitForElementNotVisible('.play-icon')
 
         .waitForElementVisible('#buttonPlugin14')

--- a/tests/nightwatch/tests/testHelpButton/testHelpButton.js
+++ b/tests/nightwatch/tests/testHelpButton/testHelpButton.js
@@ -4,7 +4,7 @@ module.exports = {
         .url("http://localhost:8000/player/index.html?id=video-remote-1")
         .waitForElementVisible('body', 1000)
         .assert.visible('.play-icon')
-        .click('.videoWrapper')
+        .click('#playerContainer_videoContainer')
         .waitForElementNotVisible('.play-icon')
 
         .waitForElementVisible('#buttonPlugin5')

--- a/tests/nightwatch/tests/testRateButton/testRateButton.js
+++ b/tests/nightwatch/tests/testRateButton/testRateButton.js
@@ -4,7 +4,7 @@ module.exports = {
         .url("http://localhost:8000/player/index.html?id=video-remote-1")
         .waitForElementVisible('body', 1000)
         .assert.visible('.play-icon')
-        .click('.videoWrapper')
+        .click('#playerContainer_videoContainer')
         .waitForElementNotVisible('.play-icon')
 
         .waitForElementVisible('#buttonPlugin8')


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR adds a feature to allow users to override the videoQualityStrategy with a URL param, or fixed config param, to load the highest or lowest resolution by default.
This PR respects the max resolution parameter of the LimitedBestFitVideoQualityStrategy and only takes the highest that is allowed by it.
This PR also fixes a typo to that prevented the config.player.videoQualityStrategy strategy from loading. Therefore, this PR changed the config to BestFitVideoQualityStrategy because that is what was being loaded prior to this PR. Otherwise this PR might break adopters expectations by loading the Limited strategy.
This PR also changes the Log kLevel references to reference the constant class. The paella.log.kLevel is not recognized as being defined.
The PR also changes 3 unrelated tests with the correct top level onClick element id.
 
Two ways to define the default resolution. The URL param "res" has priority over config param.
-  URL param "res", with options "low" or "high".  Example watch.html?id=123&res=high will load the highest available resolution on load by default (for non-HLS progressive download videos)
- config value, with options "low" or "high" example: "defaultQualityLevel": "high".

Use Cases:
- res=low, our site has a lot of users with big screens but very bad network connection. They need the ability to override all strategies to force load the lowest possible resolution in order to watch the video (this is a common scenario for our users).
- res=high, our site has a lot of embedded videos that are given a relatively small iframe window. The users want the highest possible resolution to load by default in that tiny window. (another common scenario for our site).

## What is the current behavior? (You can also link to an open issue here)
The strategy decides which resolution to load on startup. The user cannot override this with a default value.

## What does this implement/fix? Explain your changes.
It adds the ability for user or site to override the video quality strategy with highest or lowest res.
It fixes the log level error when passing logLevel=DEBUG on the URL param
It fixes the load of the config.player.videoQualityStrategy
It makes the "npm test" tests pass.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
No, but the issue was raised on list.

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
No breaking changes except that the config.player.videoQualityStrategy will now be honored (which is why this PR changes that default config to the one that has  been loading before this PR)

## Any other comments?
[EDIT] updated the docs to add user documentation for the URL "res" param option (also updated  it to mention the start-end URL param pair)

