### PR TITLE
Issue#568 FrameControl hidePopUp fix and a new feature to hide across Popup types

### DIFF
--- a/src/05_plugin_base.js
+++ b/src/05_plugin_base.js
@@ -303,7 +303,9 @@ class PopUpContainer extends paella.DomNode {
 
 	hideContainer(identifier, button, swapFocus = false) {
 		var container = this.containers[identifier];
-		hideContainer.apply(this,[identifier,container,swapFocus]);
+		if (container) {
+			hideContainer.apply(this,[identifier,container,swapFocus]);
+		}
 	}
 
 	showContainer(identifier, button, swapFocus = false) {

--- a/src/06_ui_controls.js
+++ b/src/06_ui_controls.js
@@ -714,7 +714,7 @@ class PlaybackControl extends paella.DomNode {
 		}
 		if (containerToHide) {
 			var hideId = containerToHide.currentContainerId;
-			var hidePugin = paella.pluginManager.getPlugin(containerToHide.currentContainerId);
+			var hidePugin = paella.pluginManager.getPlugin(hideId);
 			if (hidePugin) {
 				containerToHide.hideContainer(hideId,hidePugin.button,swapFocus);
 			}

--- a/src/06_ui_controls.js
+++ b/src/06_ui_controls.js
@@ -699,6 +699,26 @@ class PlaybackControl extends paella.DomNode {
 	showPopUp(identifier,button,swapFocus=false) {
 		this.popUpPluginContainer.showContainer(identifier,button,swapFocus);
 		this.timeLinePluginContainer.showContainer(identifier,button,swapFocus);
+		this.hideCrossTimelinePopupButtons(identifier,this.popUpPluginContainer,this.timeLinePluginContainer,button,swapFocus);
+	}
+
+	// Hide popUpPluginContainer when a timeLinePluginContainer popup opens, and visa versa
+	hideCrossTimelinePopupButtons(identifier, popupContainer, timelineContainer, button, swapFocus=true) {
+		var containerToHide = null;
+		if (popupContainer.containers[identifier]
+			&& timelineContainer.containers[timelineContainer.currentContainerId]) {
+			containerToHide = timelineContainer;
+		} else if (timelineContainer.containers[identifier]
+			&& popupContainer.containers[popupContainer.currentContainerId]) {
+			containerToHide = popupContainer;
+		}
+		if (containerToHide) {
+			var hideId = containerToHide.currentContainerId;
+			var hidePugin = paella.pluginManager.getPlugin(containerToHide.currentContainerId);
+			if (hidePugin) {
+				containerToHide.hideContainer(hideId,hidePugin.button,swapFocus);
+			}
+		}
 	}
 
 	hidePopUp(identifier,button,swapFocus=true) {


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix for #568 and feature to hide button popups between TimeLine and PopUp containers.

## What is the current behavior? (You can also link to an open issue here)
#568 for frameControl popup not closing.
And when a TimeLine popup is activated, the PopUp popups remain popped up, instead of hiding.

## What does this implement/fix? Explain your changes.
It enables frameControl popup to close. It also will close frameControl when another popup is popped up.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
close #568 


## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
The feature might confuse people if they expect the timeLine popups to remain popped up when a PopUp popup pops up.

