### PR TITLE
Issue #570 PluginButton action API fix

### DIFF
--- a/src/05_plugin_base.js
+++ b/src/05_plugin_base.js
@@ -666,15 +666,13 @@ class ButtonPlugin extends paella.UIPlugin {
 			self.plugin.action(self);
 		}
 		
-		if (plugin.getButtonType() == paella.ButtonPlugin.type.actionButton) {
-			$(elem).click(function(event) {
-				onAction(this);
-			});
-			$(elem).keypress(function(event) {
-				 onAction(this);
-				 event.preventDefault();
-			});
-		}
+		$(elem).click(function(event) {
+			onAction(this);
+		});
+		$(elem).keypress(function(event) {
+			 onAction(this);
+			 event.preventDefault();
+		});
 
 		$(elem).focus(function(event) {
 			plugin.expand();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This pull reverts a UPV change from March 12, 2020 that added an (unnecessary?) restriction to the PluginButton action() API.


## What is the current behavior? (You can also link to an open issue here)
PluginButtons have to be a specific type of button in order to implement the action() API starting in Paella 6.4.3

## What does this implement/fix? Explain your changes.
This pull opens the action() API option to all PlugButton types, as it was previous to 6.4.3.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
close #570


## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
I am unable to infer the motivation for limiting PluginButton action() API in 6.4.3. There does not appear to be harm in allowing it as before.

The commit that this pull partially reverts: 8578142#L636-L651
