### PR TITLE
Issue#412 additional protection for seek-to-start during play in ended state

### DIFF
--- a/src/04_video_container.js
+++ b/src/04_video_container.js
@@ -1028,17 +1028,25 @@ class VideoContainer extends paella.VideoContainerBase {
 
 	// Playback and status functions
 	play() {
+		let thisClass = this;
 		return new Promise((resolve,reject) => {
 			this.ended()
 				.then((ended) => {
 					if (ended) {
+						// Wait for seek to complete before requesting play, or risk media freeze-up (i.e. FireFox)
+						$(document).bind(paella.events.seekToTime, function (event, params) {
+							$(document).unbind(paella.events.seekToTime);
+							// Now it's safe to call this method again. Ended state evaluates to false because of the seek.
+							return thisClass.play();
+						});
 						this._streamProvider.startTime = 0;
 						this.seekToTime(0);
 					}
 					else {
 						this.streamProvider.startTime = this._startTime;
+						// Call separately from the ended state handling, or risk media freeze-up.
+						return this.streamProvider.callPlayerFunction('play');
 					}
-					return this.streamProvider.callPlayerFunction('play')
 				})
 				.then(() => {
 					super.play();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This change is protection for media being asked to play when still in a seeking state.

The patch is for the race condition where the video has ended, the user clicks play to replay, the code seeks the video to the start time and calls play on the media before the seek on it has finished. In certain browsers, particularly Firefox, the media is put into  'suspended' state when play is requested while the video is in seeking state. This freezes up the media playback for a long while.

## What is the current behavior? (You can also link to an open issue here)
Most of the time, all goes well. Clicking replay does a quick seek to start and plays the video Ok. Occasionally, the browser is overworked or there is a bad network  and the seek to start takes longer than the request to play the video. Certain browsers will freeze up the video when that happens. This is related to issue #412.

## What does this implement/fix? Explain your changes.
It adds a listener to for seek-to-start to end before running the request to play the video.

