### PR TITLE
Fix for early loadCaption() prior to video container creation

### DIFF
--- a/src/06_1_captions.js
+++ b/src/06_1_captions.js
@@ -180,9 +180,13 @@ class Caption {
 			dataType: "text"
 		})
 		.then(function(dataRaw){
-			var parser = captionParserManager._formats[self._format];			
+			var parser = captionParserManager._formats[self._format];
 			if (parser == undefined) {
 				paella.log.debug("Error adding captions: Format not supported!");
+				if (!paella.player.videoContainer) {
+					paella.log.debug("Video container is not ready, delaying parse until next reload");
+					return;
+				}
 				paella.player.videoContainer.duration(true)
 				.then((duration)=>{
 					self._captions = [{


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This pull prevents a load time console error log when loading a video with a caption attachment:
`jQuery.Deferred exception: null is not an object (evaluating 'paella.player.videoContainer.duration')`

## What is the current behavior? (You can also link to an open issue here)
The  /src/10_loader.js calls `this.loadCaptions(data.captions);`prior to the videoContainer being instantiated. The caption  class tries to get duration directly from the video Container. The red console error "null is not an object" shows in the console log.

## What does this implement/fix? Explain your changes.
This pull prevents a red console error log that distracts users that are debugging other issues. Captions are eventually loaded later on during the "reloadCaptions()".

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
No breaking change.
