### PR TITLE
For #441, enable videoContainer and streamProvider to reference the same audioPlayer

### DIFF
--- a/src/04_video_container.js
+++ b/src/04_video_container.js
@@ -1263,8 +1263,16 @@ class VideoContainer extends paella.VideoContainerBase {
 		this.streamProvider.stopVideoSync();
 		return new Promise((resolve) => {
 			let audioSet = false;
-			let firstAudioPlayer = null;
 			let promises = [];
+			// Allow the firstAudioPlayer to be the player that matches the audio lang
+			let firstAudioPlayer = this.streamProvider.players.find((player) => {
+				if (player.stream.audioTag == lang) {
+					audioSet = true;
+					this._audioPlayer = player;
+				}
+				return player.stream.audioTag == lang;
+			});
+                        // Otherwise, let the firstAudioPlayer be different than this._audioPlayer
 			this.streamProvider.players.forEach((player) => {
 				if (!firstAudioPlayer) {
 					firstAudioPlayer = player;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This patch might only affect our site because we rely on  the VideoContainer's mainAudio player and the StreamProvider's mainAudio player to be the same player. It might not otherwise matter that the mainAudioPlayer for the VideoContainer is different than the mainAudioPlayer associated to the StreamProvider.

## What is the current behavior? (You can also link to an open issue here)
This pull is related to the issue, with a confusing discussion thread, #441. 

## What does this implement/fix? Explain your changes.
This patch synchronizes the mainAudioPlayer to be the same player for VideoContainer and the StreamProvider. 
Otherwise, the firstMainAudioPlayer is the first stream found, which does *not* have to have an audioTag. Or, if it does have an audioTag, its tag does not have to match the requested lang. After the fistMainAudioPlayer is found, the current loop checks for an audioTag in the rest of the players.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
close #441


## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
I don't know what could break by allowing the fistAudioPlayer to match the audioPlayer that is loaded by the streamProvider.

