### PR TITLE
Fix for Android touchend leaving scrubber without event.pageX

### DIFF
--- a/src/01_utils.js
+++ b/src/01_utils.js
@@ -31,7 +31,9 @@
 		down(targetObject,event) {
 			this.targetObject = targetObject;
 			if (this.targetObject && this.targetObject.down) {
-				this.targetObject.down(event,event.pageX,event.pageY);
+				const pageX = event.pageX || (event.changedTouches.length > 0 ? event.changedTouches[0].pageX : 0);
+				const pageY = event.pageY || (event.changedTouches.length > 0 ? event.changedTouches[0].pageY : 0);
+				this.targetObject.down(event,pageX,pageY);
 				event.cancelBubble = true;
 			}
 			return false;
@@ -39,7 +41,9 @@
 	
 		up(event) {
 			if (this.targetObject && this.targetObject.up) {
-				this.targetObject.up(event,event.pageX,event.pageY);
+				const pageX = event.pageX || (event.changedTouches.length > 0 ? event.changedTouches[0].pageX : 0);
+				const pageY = event.pageY || (event.changedTouches.length > 0 ? event.changedTouches[0].pageY : 0);
+				this.targetObject.up(event,pageX,pageY);
 				event.cancelBubble = true;
 			}
 			this.targetObject = null;
@@ -48,7 +52,9 @@
 	
 		out(event) {
 			if (this.targetObject && this.targetObject.out) {
-				this.targetObject.out(event,event.pageX,event.pageY);
+				const pageX = event.pageX || (event.changedTouches.length > 0 ? event.changedTouches[0].pageX : 0);
+				const pageY = event.pageY || (event.changedTouches.length > 0 ? event.changedTouches[0].pageY : 0);
+				this.targetObject.out(event,pageX,pageY);
 				event.cancelBubble = true;
 			}
 			return false;
@@ -56,7 +62,9 @@
 	
 		move(event) {
 			if (this.targetObject && this.targetObject.move) {
-				this.targetObject.move(event,event.pageX,event.pageY);
+				const pageX = event.pageX || (event.changedTouches.length > 0 ? event.changedTouches[0].pageX : 0);
+				const pageY = event.pageY || (event.changedTouches.length > 0 ? event.changedTouches[0].pageY : 0);
+				this.targetObject.move(event,pageX,pageY);
 				event.cancelBubble = true;
 			}
 			return false;
@@ -64,7 +72,9 @@
 	
 		over(event) {
 			if (this.targetObject && this.targetObject.over) {
-				this.targetObject.over(event,event.pageX,event.pageY);
+				const pageX = event.pageX || (event.changedTouches.length > 0 ? event.changedTouches[0].pageX : 0);
+				const pageY = event.pageY || (event.changedTouches.length > 0 ? event.changedTouches[0].pageY : 0);
+				this.targetObject.over(event,pageX,pageY);
 				event.cancelBubble = true;
 			}
 			return false;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This pull adds protection from NaN seekTo from Android  mobile scrub bar "touchend" event.
The Android touch often goes off the tiny area of the scrub bar causing the Touch event to have a changedTouch array of pageX and pageY, but, no pageX or pageY on the touch event itself. This causes a seekTo NaN because there is no event.pageX on the touch event. 

## What is the current behavior? (You can also link to an open issue here)
The seekTo NaN frequently causes the hls.js player (Android Chrome) to freeze. I don't know why this happens to Android more than iOS. It's possible that hls.js is more sensitive to a bad seekTo value than Safari native hls driver.

## What does this implement/fix? Explain your changes.
This PR introduces fall back protection, to look for changedTouch array pageX and pageY if none are found on the main Touch event object.

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
The PR does not change the default behavior. It is for fallback seekTo number protection.
