### PR TITLE
HLS add initialQualityLevel to config keys

### DIFF
--- a/plugins/es.upv.paella.hlsPlayer/hls-player.js
+++ b/plugins/es.upv.paella.hlsPlayer/hls-player.js
@@ -12,6 +12,7 @@
 				debug: false,
 				defaultAudioCodec: undefined,
 				initialLiveManifestSize: 1,
+				initialQualityLevel: 1,
 				maxBufferLength: 30,
 				maxMaxBufferLength: 600,
 				maxBufferSize: 60*1000*1000,


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This pull allows HLS *initialQualityLevel* to be set by Paella config file, instead of always defaulting to 1 (a low res level).

## What is the current behavior? (You can also link to an open issue here)

An *initialQualityLevel* requested in the Paella config file HLSFactory config area is ignored because it is not part of the  hls-player.js defined config keys. Only keys defined in hls-player.js are retrieved from the Paella config file. 

## What does this implement/fix? Explain your changes.
It allows a site to select a default HLS  *initialQualityLevel* level higher than 1.

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
No known breaking changes. The hls-player.js already has protection for configure *initialQualityLevel* higher than existing load levels.
