### PR TITLE
Introduce Cookieconsent and Opt-Out for Matomo for better privacy control

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -175,7 +175,8 @@
         "server": "http://localhost/piwik/",
         "site_id": 1,
         "heartbeat": 30,
-        "client_id": "Paella Player"
+        "client_id": "Paella Player",
+        "privacy_policy_url": "https://matomo.org/blog/2018/04/how-should-i-write-my-privacy-notice-for-matomo-analytics-under-gdpr/"
       },
       "org.opencast.usertracking.x5gonSaverPlugIn": {
         "enabled": false,

--- a/config/config.json
+++ b/config/config.json
@@ -172,11 +172,14 @@
       "es.upv.paella.usertracking.piwikSaverPlugIn": { "enabled": false, "tracker":"http://localhost/piwik/", "siteId": "1" },
       "org.opencast.usertracking.MatomoSaverPlugIn": {
         "enabled": false,
-        "server": "http://localhost/piwik/",
+        "server": "http://localhost/matomo",
         "site_id": 1,
+        "tracking_client_name": "matomo",
         "heartbeat": 30,
         "client_id": "Paella Player",
-        "privacy_policy_url": "https://matomo.org/blog/2018/04/how-should-i-write-my-privacy-notice-for-matomo-analytics-under-gdpr/"
+        "privacy_policy_url": "https://matomo.org/blog/2018/04/how-should-i-write-my-privacy-notice-for-matomo-analytics-under-gdpr/",
+        "cookieconsent_base_color": "#1d8a8a",
+        "cookieconsent_highlight_color": "#62ffaa"
       },
       "org.opencast.usertracking.x5gonSaverPlugIn": {
         "enabled": false,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -200,6 +200,9 @@ gulp.task("copy", function() {
 			.pipe(gulp.dest(`${config.outDir}player/javascript`)),
 
 		gulp.src('node_modules/hls.js/dist/hls.min.js')
+			.pipe(gulp.dest(`${config.outDir}/player/javascript`)),
+
+		gulp.src('node_modules/cookieconsent/build/cookieconsent.min.js')
 			.pipe(gulp.dest(`${config.outDir}/player/javascript`))
 	];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2285,6 +2285,11 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "cookieconsent": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookieconsent/-/cookieconsent-3.1.1.tgz",
+      "integrity": "sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag=="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bg2e-js": "=1.3.32",
     "jquery": "^3.5.1",
     "lunr": "^2.3.9",
-    "requirejs": "^2.3.6"
+    "requirejs": "^2.3.6",
+    "cookieconsent": "^3.1.1"
   }
 }

--- a/plugins/org.opencast.usertracking.MatomoSaverPlugIn/localization/de.json
+++ b/plugins/org.opencast.usertracking.MatomoSaverPlugIn/localization/de.json
@@ -1,0 +1,7 @@
+{
+  "matomo_message": "Diese Seite würde gerne Matomo einbinden, um Informationen über die Nutzung der Videos zu sammeln.",
+  "matomo_more_info": "Mehr erfahren",
+  "matomo_accept": "Erlauben",
+  "matomo_deny": "Ablehnen",
+  "matomo_policy": "Cookie-Richtlinie"
+} 

--- a/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.less
+++ b/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.less
@@ -1,0 +1,341 @@
+.cc-window {
+    opacity: 1;
+    transition: opacity 1s ease
+}
+
+.cc-window.cc-invisible {
+    opacity: 0
+}
+
+.cc-animate.cc-revoke {
+    transition: transform 1s ease
+}
+
+.cc-animate.cc-revoke.cc-top {
+    transform: translateY(-2em)
+}
+
+.cc-animate.cc-revoke.cc-bottom {
+    transform: translateY(2em)
+}
+
+.cc-animate.cc-revoke.cc-active.cc-bottom,
+.cc-animate.cc-revoke.cc-active.cc-top,
+.cc-revoke:hover {
+    transform: translateY(0)
+}
+
+.cc-grower {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 1s
+}
+
+.cc-link,
+.cc-revoke:hover {
+    text-decoration: underline
+}
+
+.cc-revoke,
+.cc-window {
+    position: fixed;
+    overflow: hidden;
+    box-sizing: border-box;
+    font-family: Helvetica, Calibri, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.5em;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    z-index: 9999
+}
+
+.cc-window.cc-static {
+    position: static
+}
+
+.cc-window.cc-floating {
+    padding: 2em;
+    max-width: 24em;
+    -ms-flex-direction: column;
+    flex-direction: column
+}
+
+.cc-window.cc-banner {
+    padding: 1em 1.8em;
+    width: 100%;
+    -ms-flex-direction: row;
+    flex-direction: row
+}
+
+.cc-revoke {
+    padding: .5em
+}
+
+.cc-header {
+    font-size: 18px;
+    font-weight: 700
+}
+
+.cc-btn,
+.cc-close,
+.cc-link,
+.cc-revoke {
+    cursor: pointer
+}
+
+.cc-link {
+    opacity: .8;
+    display: inline-block;
+    padding: .2em
+}
+
+.cc-link:hover {
+    opacity: 1
+}
+
+.cc-link:active,
+.cc-link:visited {
+    color: initial
+}
+
+.cc-btn {
+    display: block;
+    padding: .4em .8em;
+    font-size: .9em;
+    font-weight: 700;
+    border-width: 2px;
+    border-style: solid;
+    text-align: center;
+    white-space: nowrap
+}
+
+.cc-highlight .cc-btn:first-child {
+    background-color: transparent;
+    border-color: transparent
+}
+
+.cc-highlight .cc-btn:first-child:focus,
+.cc-highlight .cc-btn:first-child:hover {
+    background-color: transparent;
+    text-decoration: underline
+}
+
+.cc-close {
+    display: block;
+    position: absolute;
+    top: .5em;
+    right: .5em;
+    font-size: 1.6em;
+    opacity: .9;
+    line-height: .75
+}
+
+.cc-close:focus,
+.cc-close:hover {
+    opacity: 1
+}
+
+.cc-revoke.cc-top {
+    top: 0;
+    left: 3em;
+    border-bottom-left-radius: .5em;
+    border-bottom-right-radius: .5em
+}
+
+.cc-revoke.cc-bottom {
+    bottom: 0;
+    left: 3em;
+    border-top-left-radius: .5em;
+    border-top-right-radius: .5em
+}
+
+.cc-revoke.cc-left {
+    left: 3em;
+    right: unset
+}
+
+.cc-revoke.cc-right {
+    right: 3em;
+    left: unset
+}
+
+.cc-top {
+    top: 1em
+}
+
+.cc-left {
+    left: 1em
+}
+
+.cc-right {
+    right: 1em
+}
+
+.cc-bottom {
+    bottom: 1em
+}
+
+.cc-floating>.cc-link {
+    margin-bottom: 1em
+}
+
+.cc-floating .cc-message {
+    display: block;
+    margin-bottom: 1em
+}
+
+.cc-window.cc-floating .cc-compliance {
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto
+}
+
+.cc-window.cc-banner {
+    -ms-flex-align: center;
+    align-items: center
+}
+
+.cc-banner.cc-top {
+    left: 0;
+    right: 0;
+    top: 0
+}
+
+.cc-banner.cc-bottom {
+    left: 0;
+    right: 0;
+    bottom: 0
+}
+
+.cc-banner .cc-message {
+    display: block;
+    -ms-flex: 1 1 auto;
+    flex: 1 1 auto;
+    max-width: 100%;
+    margin-right: 1em
+}
+
+.cc-compliance {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-align: center;
+    align-items: center;
+    -ms-flex-line-pack: justify;
+    align-content: space-between
+}
+
+.cc-floating .cc-compliance>.cc-btn {
+    -ms-flex: 1;
+    flex: 1
+}
+
+.cc-btn+.cc-btn {
+    margin-left: .5em
+}
+
+@media print {
+
+    .cc-revoke,
+    .cc-window {
+        display: none
+    }
+}
+
+@media screen and (max-width:900px) {
+    .cc-btn {
+        white-space: normal
+    }
+}
+
+@media screen and (max-width:414px) and (orientation:portrait),
+screen and (max-width:736px) and (orientation:landscape) {
+    .cc-window.cc-top {
+        top: 0
+    }
+
+    .cc-window.cc-bottom {
+        bottom: 0
+    }
+
+    .cc-window.cc-banner,
+    .cc-window.cc-floating,
+    .cc-window.cc-left,
+    .cc-window.cc-right {
+        left: 0;
+        right: 0
+    }
+
+    .cc-window.cc-banner {
+        -ms-flex-direction: column;
+        flex-direction: column
+    }
+
+    .cc-window.cc-banner .cc-compliance {
+        -ms-flex: 1 1 auto;
+        flex: 1 1 auto
+    }
+
+    .cc-window.cc-floating {
+        max-width: none
+    }
+
+    .cc-window .cc-message {
+        margin-bottom: 1em
+    }
+
+    .cc-window.cc-banner {
+        -ms-flex-align: unset;
+        align-items: unset
+    }
+
+    .cc-window.cc-banner .cc-message {
+        margin-right: 0
+    }
+}
+
+.cc-floating.cc-theme-classic {
+    padding: 1.2em;
+    border-radius: 5px
+}
+
+.cc-floating.cc-type-info.cc-theme-classic .cc-compliance {
+    text-align: center;
+    display: inline;
+    -ms-flex: none;
+    flex: none
+}
+
+.cc-theme-classic .cc-btn {
+    border-radius: 5px
+}
+
+.cc-theme-classic .cc-btn:last-child {
+    min-width: 140px
+}
+
+.cc-floating.cc-type-info.cc-theme-classic .cc-btn {
+    display: inline-block
+}
+
+.cc-theme-edgeless.cc-window {
+    padding: 0
+}
+
+.cc-floating.cc-theme-edgeless .cc-message {
+    margin: 2em 2em 1.5em
+}
+
+.cc-banner.cc-theme-edgeless .cc-btn {
+    margin: 0;
+    padding: .8em 1.8em;
+    height: 100%
+}
+
+.cc-banner.cc-theme-edgeless .cc-message {
+    margin-left: 1em
+}
+
+.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn {
+    margin-left: 0
+}


### PR DESCRIPTION

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This is an enhancement to the org.opencast.usertracking.MatomoSaverPlugIn. A banner is now shown obligatory that provides a choice if tracking is allowed or not. Our state privacy officer demands such opt-out choices for Matomo because of GDPR, even if Matomo is configured correctly not to store IP-addresses or other personal data. 

As I am not a legal expert, I naively guess that similar restrictions apply to the other (european) users too, so I hope it is okay, that the banner is not optional. 

Additionally I made the name of the trackingclient selectable, as on newer installations it seems that it has been changed from "piwik.[js|php]" to "matomo.[js|php]"

## What is the current behavior? (You can also link to an open issue here)
Currently no information to the user is shown, if the Matomo plugin is active and tracking the user.

## What does this implement/fix? Explain your changes.
A banner is shown on the top of the page with the choice to allow or deny the Matomo tracking. The choice is stored in the browser. After the choice has been made it can be reverted, as a cookie policies button is still hidden at the top left of the page.


## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
close #


## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
Some more variables have been introduced to the config:
"tracking_client_name": "matomo", [piwik|matomo]
"privacy_policy_url": "https://matomo.org/blog/2018/04/how-should-i-write-my-privacy-notice-for-matomo-analytics-under-gdpr/",
placeholder should be changed to the institutions privacy policy page
"cookieconsent_base_color": "#1d8a8a", 
"cookieconsent_highlight_color": "#62ffaa"
use any color you want for the banner.

## Any other comments?
…
