### PR TITLE
Made consent for Matomo tracking optional in configuration.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -177,6 +177,7 @@
         "tracking_client_name": "matomo",
         "heartbeat": 30,
         "client_id": "Paella Player",
+        "ask_for_concent": true,
         "privacy_policy_url": "https://matomo.org/blog/2018/04/how-should-i-write-my-privacy-notice-for-matomo-analytics-under-gdpr/",
         "cookieconsent_base_color": "#1d8a8a",
         "cookieconsent_highlight_color": "#62ffaa"

--- a/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
+++ b/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
@@ -10,6 +10,7 @@ paella.addPlugin(function() {
           heartbeat = this.config.heartbeat,
           privacy_url = this.config.privacy_policy_url,
           tracking_client = this.config.tracking_client_name,
+          ask_for_concent = this.config.ask_for_concent,
           cookieconsent_base_color = this.config.cookieconsent_base_color,
           cookieconsent_highlight_color = this.config.cookieconsent_highlight_color,
           thisClass = this,
@@ -23,10 +24,10 @@ paella.addPlugin(function() {
       function trackMatomo() {
         if (isTrackingPermission() && !tracked && server && site_id){
           if (server.substr(-1) != '/') server += '/';
-          paella.require(server + tracking_client_name + ".js")
+          paella.require(server + tracking_client + ".js")
             .then((matomo) => {
               paella.log.debug("Matomo Analytics Enabled");
-              paella.userTracking.matomotracker = Matomo.getAsyncTracker( server + tracking_client_name + ".php", site_id );
+              paella.userTracking.matomotracker = Matomo.getAsyncTracker( server + tracking_client + ".php", site_id );
               paella.userTracking.matomotracker.client_id = thisClass.config.client_id;
               if (heartbeat && heartbeat > 0) paella.userTracking.matomotracker.enableHeartBeatTimer(heartbeat);
               if (Matomo && Matomo.MediaAnalytics) {
@@ -151,13 +152,17 @@ paella.addPlugin(function() {
           trackMatomo();
       };
 
-      initTranslate(navigator.language, function () {
-          paella.log.debug('Matomo: Successfully translated.');
-          initCookieNotification();
-      }, function () {
-          paella.log.debug('Matomo: Error translating.');
-          initCookieNotification();
-      });
+      if (ask_for_concent) {
+        initTranslate(navigator.language, function () {
+            paella.log.debug('Matomo: Successfully translated.');
+            initCookieNotification();
+        }, function () {
+            paella.log.debug('Matomo: Error translating.');
+            initCookieNotification();
+        });
+      } else {
+        trackingPermission = true;
+      }
 
       onSuccess(trackMatomo());
 


### PR DESCRIPTION
I thought about it and decided as not all Paella and Opencast users are in the EU to make the consent for tracking optional. 

New configuration option `"ask_for_concent": true`

Thanks for merging the original PR so quickly... I did not expect that. :-)