### PR TITLE
Update 06_1_captions.js

### DIFF
--- a/src/06_1_captions.js
+++ b/src/06_1_captions.js
@@ -177,7 +177,10 @@ class Caption {
 			url: self._url,
 			cache:false,
 			type: 'get',
-			dataType: "text"
+			dataType: "text",
+			xhrFields: {
+				withCredentials: true
+			}			
 		})
 		.then(function(dataRaw){
 			var parser = captionParserManager._formats[self._format];


### PR DESCRIPTION
Allow xhr credentials to be sent to the captions server.


<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature for external media/captions that require user authentication/authorization.
The media and captions files are not served by the Player, but from a external server. 

## What is the current behavior? (You can also link to an open issue here)
Captions load fails after being redirected from the SSO authentication server.
error “CORS Missing Allow Credentials”

## What does this implement/fix? Explain your changes.
Sending the credentials to the server, after being authenticated.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
close #


## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
…


## Any other comments?
Access-Control-Allow-Credentials should be enabled in the server side.
Access-Control-Allow-Origin header is also required.