### PR TITLE
Fix log not enabled issue

### DIFF
--- a/src/01_utils.js
+++ b/src/01_utils.js
@@ -560,12 +560,12 @@ paella.utils.uuid = function() {
         }
 	}
     
-    Log.kLevelError    = 1;
-    Log.kLevelWarning  = 2;
-    Log.kLevelDebug    = 3;
-    Log.kLevelLog      = 4;
-    
-    paella.log = new Log();	
+	paella.log = new Log();
+	paella.log.kLevelError      = 1;
+	paella.log.kLevelWarning    = 2;
+	paella.log.kLevelDebug      = 3;
+	paella.log.kLevelLog        = 4;
+	
 })();
 
 paella.AntiXSS = {


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Fixes the logging mode that in the standalone version won't work.


## What is the current behavior? (You can also link to an open issue here)
If you add the logging mode to the URL parameters (Example: `&log=debug`) as the documentation says, nothing happens. 


## What does this implement/fix? Explain your changes.
This changes how are initialized the parameters because that there were not loaded.


## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
close #
No

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
…
No

## Any other comments?
…
Thanks for your great work Paella Team :tada: 