### PR TITLE
Fixes Matomo Media Analytics Tool title

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -180,7 +180,8 @@
         "ask_for_concent": true,
         "privacy_policy_url": "https://matomo.org/blog/2018/04/how-should-i-write-my-privacy-notice-for-matomo-analytics-under-gdpr/",
         "cookieconsent_base_color": "#1d8a8a",
-        "cookieconsent_highlight_color": "#62ffaa"
+        "cookieconsent_highlight_color": "#62ffaa",
+        "html_title": false
       },
       "org.opencast.usertracking.x5gonSaverPlugIn": {
         "enabled": false,

--- a/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
+++ b/plugins/org.opencast.usertracking.MatomoSaverPlugIn/usertracking_matomo_saver.js
@@ -168,6 +168,11 @@ paella.addPlugin(function() {
 
     } // checkEnabled
 
+    setVideoTitleAttr(){
+      var video_element = video_element = document.getElementsByTagName("video");
+      video_element.video_0.setAttribute("data-matomo-title", document.title);
+    }
+
     registerVisit() {
       var title,
           event_id,
@@ -176,18 +181,25 @@ paella.addPlugin(function() {
           presenter,
           view_mode;
 
-      if (paella.opencast && paella.opencast._episode) {
+      if ((paella.opencast != undefined) && (paella.opencast._episode != undefined)) {
         title = paella.opencast._episode.dcTitle;
         event_id = paella.opencast._episode.id;
         presenter = paella.opencast._episode.dcCreator;
         paella.userTracking.matomotracker.setCustomVariable(5, "client",
           (paella.userTracking.matomotracker.client_id || "Paella Opencast"));
       } else {
+        title = this.loadTitle();
+        // Add title for Matomo Media Analytics.
+        if (this.config.html_title){
+          this.setVideoTitleAttr();
+        } else{
+          Matomo.MediaAnalytics.setMediaTitleFallback(function (mediaElement) {return title; });
+        }
         paella.userTracking.matomotracker.setCustomVariable(5, "client",
-          (paella.userTracking.matomotracker.client_id || "Paella Standalone"));
+          (paella.userTracking.matomotracker.client_id || "Paella Standalone"));          
       }
 
-      if (paella.opencast && paella.opencast._episode && paella.opencast._episode.mediapackage) {
+      if ((paella.opencast != undefined) && (paella.opencast._episode != undefined) && (paella.opencast._episode.mediapackage != undefined)) {
         series_id = paella.opencast._episode.mediapackage.series;
         series_title = paella.opencast._episode.mediapackage.seriestitle;
       }
@@ -220,7 +232,7 @@ paella.addPlugin(function() {
 
         var value = "";
 
-        try {
+        try {     
           value = JSON.stringify(params);
         } catch(e) {}
 


### PR DESCRIPTION
The media title was only sending to MMAT when was integred in Opencast,
but no with Paella player as standalone. This fix enables the title
to be send to Matomo MAT and ads a fallback option "html_title" when is
requiered to get the html title instead of the name of the video.


<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix to Matomo Plugin


## What is the current behavior? (You can also link to an open issue here)
The Matomo Media Analytics Tool was not able to get the video title


## What does this implement/fix? Explain your changes.
Fixes the issue and adds a fallback option in case is necessary only the HTML title.


## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?
close #
Yes, maybe #524

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
…
Nothing


## Any other comments?
…
