### PR TITLE
replaced no-break spaces causing charset problems

### DIFF
--- a/src/02_profiles.js
+++ b/src/02_profiles.js
@@ -221,7 +221,7 @@
 
             paella.events.bind(paella.events.profileListChanged, () => {
                 if (paella.player && paella.player.videoContainer && 
-                    (!this.currentProfile || this.currentProfileName!=this.currentProfile.id))
+                    (!this.currentProfile || this.currentProfileName!=this.currentProfile.id))
                 {
                     this.setProfile(this.currentProfileName,false);
                 }

--- a/src/02_video_utils.js
+++ b/src/02_video_utils.js
@@ -94,7 +94,7 @@
 				//var selected = source[0];
 				var selected = null;
 				var win_h = $(window).height();
-				var maxRes = params.maxAutoQualityRes || 720;
+				var maxRes = params.maxAutoQualityRes || 720;
 				var diff = Number.MAX_VALUE;
 	
 				source.forEach(function(item,i) { 

--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -73,7 +73,7 @@ paella.Profiles = {
 };
 
 class RelativeVideoSize {
-	get w() { return this._w || 1280; }
+	get w() { return this._w || 1280; }
 	set w(v) { this._w = v; }
 	get h() { return this._h || 720; }
 	set h(v) { this._h = v; }
@@ -893,7 +893,7 @@ class Html5Video extends paella.VideoElementBase {
 			return this.domElement;
 		}
 		else {
-			this._video = this._video || document.createElement('video');
+			this._video = this._video || document.createElement('video');
 			return this._video;
 		}
 	}

--- a/src/04_video_container.js
+++ b/src/04_video_container.js
@@ -990,7 +990,7 @@ class StreamProvider {
 		})
 	}
 
-	get qualityStrategy() { return this._qualityStrategy || null; }
+	get qualityStrategy() { return this._qualityStrategy || null; }
 
 	get autoplay() {
 		return this.supportAutoplay && this._autoplay;
@@ -1350,7 +1350,7 @@ class VideoContainer extends paella.VideoContainerBase {
 	}
 
 	masterVideo() {
-		return this.streamProvider.mainVideoPlayer || this.audioPlayer;
+		return this.streamProvider.mainVideoPlayer || this.audioPlayer;
 	}
 
 	getVideoRect(videoIndex) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug Fix

## What is the current behavior? (You can also link to an open issue here)
When paella_player_es2015.js is (wrongly) interpreted as latin1 charset the no-break spaces present in the code convert to "Â " thus breaking it. 
```
grep --color='auto' -P -n "[\x80-\xFF]" paella_player_es2015.js | grep -v "Copyright" | iconv --from-code='latin1' --to-code='utf8'
906:            // Primero quitar los parÃ¡metros hash
918:        // Pasa los parÃ¡metros de la URL a hash. Esta acciÃ³n recargarÃ¡ la pÃ¡gina
1222:		// Muchos navegadores no proporcionan informaciÃ³n sobre la distribuciÃ³n de linux... no se puede hacer mucho mÃ¡s que esto
2297:                    (!this.currentProfile ||Â this.currentProfileName!=this.currentProfile.id))
2493:				var maxRes = params.maxAutoQualityRes ||Â 720;
2905:	get w() { return this._w ||Â 1280; }
3725:			this._video = this._video ||Â document.createElement('video');
5481:	get qualityStrategy() { return this._qualityStrategy ||Â null; }
5841:		return this.streamProvider.mainVideoPlayer ||Â this.audioPlayer;
11519:                                    name:{es:"Dos streams con posiciÃ³n dinÃ¡mica"},
11594:                                    name:{es:"Tres streams posiciÃ³n dinÃ¡mica"},
14245:		getTabName() { return "DescripciÃ³n"; }
14716:			captionContainer.innerText = caption ||Â "";
14827:					this._caption.innerText = frame.caption ||Â "";
15187:								this._qualities = this._qualities ||Â [];
15492:			return hlsConfig ||Â {
```

## What does this implement/fix? Explain your changes.
Changes the no-break whitespaces (0xC2A0) in javascript code to regular whitespaces.

## Does this [close any currently open issues](https://help.github.com/en/articles/closing-issues-using-keywords)?



## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
Rather not.


## Any other comments?
It is clear that serving the script properly by the webserver/application would fix this issue on our side, but replacing these multibyte whitespaces should not hurt anyone either.