### PR TITLE
Update base.log to paella.log for Play button on screen plugin

### DIFF
--- a/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
+++ b/plugins/es.upv.paella.playPauseButtonPlugin/playbutton_onscreen.js
@@ -74,7 +74,7 @@ paella.addPlugin(function() {
 					this.showIcon = this.showOnEnd;
 					this.checkStatus();
 				} else {
-					base.log.debug(`BTN ON SCREEN: The player is no longer in ended state.`);
+					paella.log.debug(`BTN ON SCREEN: The player is no longer in ended state.`);
 				}
 			});
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This is a bug fix for a log line in the playPauseButton plugin. 

## What is the current behavior? (You can also link to an open issue here)
The `base.log` is not longer recognized in 6.5.5, accessing methods on base throws an undefined exception.

## What does this implement/fix? Explain your changes.
It updates the log to use the new base: paella.

## Does this PR introduce a breaking change? What changes might users need to make in their application due to this PR?
There are no breaking changes

